### PR TITLE
Rename ema to rational and mark ema as deprecated

### DIFF
--- a/pyth-sdk-solana/src/state.rs
+++ b/pyth-sdk-solana/src/state.rs
@@ -248,7 +248,10 @@ pub struct PriceComp {
     pub latest:    PriceInfo,
 }
 
-/// An exponentially-weighted moving average.
+#[deprecated = "Type is renamed to Rational, please use the new name."]
+pub type Ema = Rational;
+
+/// An number represented as both `value` and also in rational as `numer/denom`.
 #[derive(
     Copy,
     Clone,
@@ -262,12 +265,9 @@ pub struct PriceComp {
     serde::Deserialize,
 )]
 #[repr(C)]
-pub struct Ema {
-    /// The current value of the EMA
+pub struct Rational {
     pub val:   i64,
-    /// numerator state for next update
     pub numer: i64,
-    /// denominator state for next update
     pub denom: i64,
 }
 
@@ -295,10 +295,10 @@ pub struct PriceAccount {
     pub last_slot:  u64,
     /// valid slot-time of agg. price
     pub valid_slot: u64,
-    /// time-weighted average price
-    pub twap:       Ema,
-    /// time-weighted average confidence interval
-    pub twac:       Ema,
+    /// exponentially moving average price
+    pub twap:       Rational,
+    /// exponentially moving average confidence interval
+    pub twac:       Rational,
     /// space for future derived values
     pub drv1:       i64,
     /// space for future derived values

--- a/pyth-sdk-solana/tests/stale_price.rs
+++ b/pyth-sdk-solana/tests/stale_price.rs
@@ -5,12 +5,12 @@ use pyth_sdk_solana::state::{
     AccKey,
     AccountType,
     CorpAction,
-    Ema,
     PriceAccount,
     PriceComp,
     PriceInfo,
     PriceStatus,
     PriceType,
+    Rational,
     MAGIC,
     VERSION_2,
 };
@@ -23,7 +23,7 @@ use common::test_instr_exec_ok;
 fn price_account_all_zero() -> PriceAccount {
     let acc_key = AccKey { val: [0; 32] };
 
-    let ema = Ema {
+    let rational = Rational {
         val:   0,
         numer: 0,
         denom: 0,
@@ -54,8 +54,8 @@ fn price_account_all_zero() -> PriceAccount {
         num_qt:     0,
         last_slot:  0,
         valid_slot: 0,
-        twap:       ema,
-        twac:       ema,
+        twap:       rational,
+        twac:       rational,
         drv1:       0,
         drv2:       0,
         prod:       acc_key,


### PR DESCRIPTION
Ema struct contains a value of a rational in both `numer / denom` and `value` (imprecise). This struct is used in some fields that hold Ema value.

It is better to rename this struct to Rational because it is representing a rational number and ensure ema is in the name of the fields that hold the ema value in rational format.

This PR does not remove Ema so it is not a breaking change. However, adds a deprecation message to Ema so users notice and move to the new struct.