### PR TITLE
Make ProductIdentifier type public

### DIFF
--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 mod price_conf;
 pub use price_conf::PriceConf;
 
-type ProductIdentifier = [u8; 32];
+pub type ProductIdentifier = [u8; 32];
 
 /// Represents availability status of a price feed.
 #[derive(


### PR DESCRIPTION
It's nice to be able to use this type to uniquely identify a price throughout a user's codebase. For example, as keys in a hashmap.