### PR TITLE
Add version to path dependencies

### DIFF
--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.1.0" }
 
 [dev-dependencies]
 solana-client = "1.8.1"

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -8,7 +8,7 @@ test-bpf = []
 no-entrypoint = []
 
 [dependencies]
-pyth-sdk-solana = { path = "../" }
+pyth-sdk-solana = { path = "../", version = "0.1.0" }
 solana-program = "1.8.1"
 bytemuck = "1.7.2"
 borsh = "0.9"


### PR DESCRIPTION
It is required for publishing package (which is going to be used in pyth2wormhole)