### PR TITLE
Expose product identifier in pyth-sdk-solana too

### DIFF
--- a/pyth-sdk-solana/src/lib.rs
+++ b/pyth-sdk-solana/src/lib.rs
@@ -13,6 +13,7 @@ pub use pyth_sdk::{
     Price,
     PriceConf,
     PriceStatus,
+    ProductIdentifier,
 };
 
 /// Maximum acceptable slot difference before price is considered to be stale.


### PR DESCRIPTION
Follow up of #16 which made it public in pyth-sdk