### PR TITLE
Update README.md

### DIFF
--- a/pyth-sdk-terra/README.md
+++ b/pyth-sdk-terra/README.md
@@ -19,7 +19,7 @@ let price_feed: PriceFeed = query_price_feed(deps.querier, contract_addr, id)?.p
 
 ### Example contract
 
-Checkout [Example Terra Contract](../examples/terra-contract/) as an example which uses Pyth Terra contract to fetch a price. This example also includes guidance for how to [write](../examples/terra-contract/Developing.md), and [deploy and query](../examples/terra-contract/tools/README.md) contracts.
+Checkout [Example Terra Contract](../examples/terra-contract/) as an example which uses Pyth Terra contract to fetch a price.
 
 ## Price Feed and Price API
 


### PR DESCRIPTION
When changing the structure of example contract a link mentioned here become invalid. 

I removed the entire sentence because the purpose of example is not teaching terra, it's mostly about how to use pyth info in terra.