### PR TITLE
Add new fields to Price Feed

### DIFF
--- a/examples/terra-contract/Cargo.toml
+++ b/examples/terra-contract/Cargo.toml
@@ -34,7 +34,7 @@ cosmwasm-storage = { version = "0.16.0" }
 cw-storage-plus = "0.8.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyth-sdk-terra = { version = "0.1.0", path = "../../pyth-sdk-terra" } # Remove path and use version only when you use this example on your own.
+pyth-sdk-terra = { version = "0.2.0", path = "../../pyth-sdk-terra" } # Remove path and use version only when you use this example on your own.
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.2.0" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.3.0" }
 
 [dev-dependencies]
 solana-client = "1.8.1"

--- a/pyth-sdk-solana/src/state.rs
+++ b/pyth-sdk-solana/src/state.rs
@@ -280,49 +280,55 @@ pub struct Rational {
 #[repr(C)]
 pub struct PriceAccount {
     /// pyth magic number
-    pub magic:      u32,
+    pub magic:          u32,
     /// program version
-    pub ver:        u32,
+    pub ver:            u32,
     /// account type
-    pub atype:      u32,
+    pub atype:          u32,
     /// price account size
-    pub size:       u32,
+    pub size:           u32,
     /// price or calculation type
-    pub ptype:      PriceType,
+    pub ptype:          PriceType,
     /// price exponent
-    pub expo:       i32,
+    pub expo:           i32,
     /// number of component prices
-    pub num:        u32,
+    pub num:            u32,
     /// number of quoters that make up aggregate
-    pub num_qt:     u32,
+    pub num_qt:         u32,
     /// slot of last valid (not unknown) aggregate price
-    pub last_slot:  u64,
+    pub last_slot:      u64,
     /// valid slot-time of agg. price
-    pub valid_slot: u64,
+    pub valid_slot:     u64,
     /// exponentially moving average price
-    pub ema_price:  Rational,
+    pub ema_price:      Rational,
     /// exponentially moving average confidence interval
-    pub ema_conf:   Rational,
+    pub ema_conf:       Rational,
+    /// unix timestamp of aggregate price
+    pub timestamp:      i64,
+    /// min publishers for valid price
+    pub min_pub:        u8,
     /// space for future derived values
-    pub drv1:       i64,
+    pub drv2:           u8,
     /// space for future derived values
-    pub drv2:       i64,
+    pub drv3:           u16,
+    /// space for future derived values
+    pub drv4:           u32,
     /// product account key
-    pub prod:       AccKey,
+    pub prod:           AccKey,
     /// next Price account in linked list
-    pub next:       AccKey,
+    pub next:           AccKey,
     /// valid slot of previous update
-    pub prev_slot:  u64,
-    /// aggregate price of previous update
-    pub prev_price: i64,
-    /// confidence interval of previous update
-    pub prev_conf:  u64,
-    /// space for future derived values
-    pub drv3:       i64,
+    pub prev_slot:      u64,
+    /// aggregate price of previous update with TRADING status
+    pub prev_price:     i64,
+    /// confidence interval of previous update with TRADING status
+    pub prev_conf:      u64,
+    /// unix timestamp of previous aggregate with TRADING status
+    pub prev_timestamp: i64,
     /// aggregate price info
-    pub agg:        PriceInfo,
+    pub agg:            PriceInfo,
     /// price components one per quoter
-    pub comp:       [PriceComp; 32],
+    pub comp:           [PriceComp; 32],
 }
 
 #[cfg(target_endian = "little")]
@@ -348,6 +354,7 @@ impl PriceAccount {
         PriceFeed::new(
             price_key.to_bytes(),
             status,
+            self.timestamp,
             self.expo,
             self.num,
             self.num_qt,
@@ -356,6 +363,9 @@ impl PriceAccount {
             self.agg.conf,
             self.ema_price.val,
             self.ema_conf.val as u64,
+            self.prev_price,
+            self.prev_conf,
+            self.prev_timestamp,
         )
     }
 }

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -8,7 +8,7 @@ test-bpf = []
 no-entrypoint = []
 
 [dependencies]
-pyth-sdk-solana = { path = "../", version = "0.2.0" }
+pyth-sdk-solana = { path = "../", version = "0.3.0" }
 solana-program = "1.8.1"
 bytemuck = "1.7.2"
 borsh = "0.9"

--- a/pyth-sdk-solana/test-contract/tests/stale_price.rs
+++ b/pyth-sdk-solana/test-contract/tests/stale_price.rs
@@ -1,4 +1,4 @@
-// #![cfg(feature = "test-bpf")] // Only runs on bpf, where solana programs run
+#![cfg(feature = "test-bpf")] // Only runs on bpf, where solana programs run
 
 use pyth_sdk_solana::state::{
     AccountType,

--- a/pyth-sdk-solana/test-contract/tests/stale_price.rs
+++ b/pyth-sdk-solana/test-contract/tests/stale_price.rs
@@ -1,15 +1,9 @@
-#![cfg(feature = "test-bpf")] // Only runs on bpf, where solana programs run
+// #![cfg(feature = "test-bpf")] // Only runs on bpf, where solana programs run
 
 use pyth_sdk_solana::state::{
-    AccKey,
     AccountType,
-    CorpAction,
     PriceAccount,
-    PriceComp,
-    PriceInfo,
     PriceStatus,
-    PriceType,
-    Rational,
     MAGIC,
     VERSION_2,
 };
@@ -21,51 +15,11 @@ mod common;
 use common::test_instr_exec_ok;
 
 fn price_account_all_zero() -> PriceAccount {
-    let acc_key = AccKey { val: [0; 32] };
-
-    let rational = Rational {
-        val:   0,
-        numer: 0,
-        denom: 0,
-    };
-
-    let price_info = PriceInfo {
-        conf:     0,
-        corp_act: CorpAction::NoCorpAct,
-        price:    0,
-        pub_slot: 0,
-        status:   PriceStatus::Unknown,
-    };
-
-    let price_comp = PriceComp {
-        agg:       price_info,
-        latest:    price_info,
-        publisher: acc_key,
-    };
-
     PriceAccount {
         magic:      MAGIC,
         ver:        VERSION_2,
         atype:      AccountType::Price as u32,
-        size:       0,
-        ptype:      PriceType::Price,
-        expo:       0,
-        num:        0,
-        num_qt:     0,
-        last_slot:  0,
-        valid_slot: 0,
-        ema_price:  rational,
-        ema_conf:   rational,
-        drv1:       0,
-        drv2:       0,
-        prod:       acc_key,
-        next:       acc_key,
-        prev_slot:  0,
-        prev_price: 0,
-        prev_conf:  0,
-        drv3:       0,
-        agg:        price_info,
-        comp:       [price_comp; 32],
+        ..Default::default()
     }
 }
 

--- a/pyth-sdk-terra/Cargo.toml
+++ b/pyth-sdk-terra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-terra"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ readme = "README.md"
 cosmwasm-std = { version = "0.16.0" }
 cosmwasm-storage = { version = "0.16.0" }
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.2.0" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.3.0" }
 schemars = "0.8.1"
 
 [dev-dependencies]

--- a/pyth-sdk-terra/schema/price_feed_response.json
+++ b/pyth-sdk-terra/schema/price_feed_response.json
@@ -29,11 +29,11 @@
         "num_publishers",
         "prev_conf",
         "prev_price",
-        "prev_timestamp",
+        "prev_publish_time",
         "price",
         "product_id",
-        "status",
-        "timestamp"
+        "publish_time",
+        "status"
       ],
       "properties": {
         "conf": {
@@ -92,8 +92,8 @@
           "type": "integer",
           "format": "int64"
         },
-        "prev_timestamp": {
-          "description": "Unix timestamp of previous aggregate with Trading status.",
+        "prev_publish_time": {
+          "description": "Publish time of previous aggregate with Trading status.",
           "type": "integer",
           "format": "int64"
         },
@@ -113,6 +113,11 @@
           "maxItems": 32,
           "minItems": 32
         },
+        "publish_time": {
+          "description": "Current price aggregation publish time",
+          "type": "integer",
+          "format": "int64"
+        },
         "status": {
           "description": "Status of price (Trading is valid).",
           "allOf": [
@@ -120,11 +125,6 @@
               "$ref": "#/definitions/PriceStatus"
             }
           ]
-        },
-        "timestamp": {
-          "description": "Unix timestamp of current price aggregation time",
-          "type": "integer",
-          "format": "int64"
         }
       }
     },

--- a/pyth-sdk-terra/schema/price_feed_response.json
+++ b/pyth-sdk-terra/schema/price_feed_response.json
@@ -27,13 +27,17 @@
         "id",
         "max_num_publishers",
         "num_publishers",
+        "prev_conf",
+        "prev_price",
+        "prev_timestamp",
         "price",
         "product_id",
-        "status"
+        "status",
+        "timestamp"
       ],
       "properties": {
         "conf": {
-          "description": "Confidence interval around the price.",
+          "description": "Confidence interval around the current aggregation price.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
@@ -77,8 +81,24 @@
           "format": "uint32",
           "minimum": 0.0
         },
+        "prev_conf": {
+          "description": "Confidence interval of previous aggregate with Trading status.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "prev_price": {
+          "description": "Price of previous aggregate with Trading status.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "prev_timestamp": {
+          "description": "Unix timestamp of previous aggregate with Trading status.",
+          "type": "integer",
+          "format": "int64"
+        },
         "price": {
-          "description": "The current price.",
+          "description": "The current aggregation price.",
           "type": "integer",
           "format": "int64"
         },
@@ -100,6 +120,11 @@
               "$ref": "#/definitions/PriceStatus"
             }
           ]
+        },
+        "timestamp": {
+          "description": "Unix timestamp of current price aggregation time",
+          "type": "integer",
+          "format": "int64"
         }
       }
     },

--- a/pyth-sdk/Cargo.toml
+++ b/pyth-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -16,7 +16,8 @@ pub type PriceIdentifier = [u8; 32];
 pub type ProductIdentifier = [u8; 32];
 
 /// Unix Timestamp is represented as number of seconds passed since Unix epoch (00:00:00 UTC on 1
-/// Jan 1970)
+/// Jan 1970). It is a signed integer because it's the standard in Unix systems and allows easier
+/// time difference.
 pub type UnixTimestamp = i64;
 
 /// Represents availability status of a price feed.

--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -71,8 +71,8 @@ pub struct PriceFeed {
     pub id:                 PriceIdentifier,
     /// Status of price (Trading is valid).
     pub status:             PriceStatus,
-    /// Unix timestamp of current price aggregation time
-    pub timestamp:          UnixTimestamp,
+    /// Current price aggregation publish time
+    pub publish_time:       UnixTimestamp,
     /// Price exponent.
     pub expo:               i32,
     /// Maximum number of allowed publishers that can contribute to a price.
@@ -93,8 +93,8 @@ pub struct PriceFeed {
     prev_price:             i64,
     /// Confidence interval of previous aggregate with Trading status.
     prev_conf:              u64,
-    /// Unix timestamp of previous aggregate with Trading status.
-    prev_timestamp:         UnixTimestamp,
+    /// Publish time of previous aggregate with Trading status.
+    prev_publish_time:      UnixTimestamp,
 }
 
 impl PriceFeed {
@@ -102,7 +102,7 @@ impl PriceFeed {
     pub fn new(
         id: PriceIdentifier,
         status: PriceStatus,
-        timestamp: UnixTimestamp,
+        publish_time: UnixTimestamp,
         expo: i32,
         max_num_publishers: u32,
         num_publishers: u32,
@@ -113,12 +113,12 @@ impl PriceFeed {
         ema_conf: u64,
         prev_price: i64,
         prev_conf: u64,
-        prev_timestamp: UnixTimestamp,
+        prev_publish_time: UnixTimestamp,
     ) -> PriceFeed {
         PriceFeed {
             id,
             status,
-            timestamp,
+            publish_time,
             expo,
             max_num_publishers,
             num_publishers,
@@ -129,7 +129,7 @@ impl PriceFeed {
             ema_conf,
             prev_price,
             prev_conf,
-            prev_timestamp,
+            prev_publish_time,
         }
     }
 
@@ -199,11 +199,13 @@ impl PriceFeed {
         }
     }
 
-    /// Get the "unchecked" previous aggregate price with Trading status.
+    /// Get the "unchecked" previous price with Trading status,
+    /// along with the timestamp at which it was generated.
     ///
-    /// Returns the previous aggregate price with the timestamp it was generated. The price might
-    /// be invalid or inaccurate at the current time; You need to check timestamp when using it.
-    /// Please use `get_current_price` where possible.
+    /// WARNING:
+    /// We make no guarantees about the unchecked price and confidence returned by
+    /// this function: it could differ significantly from the current price.
+    /// We strongly encourage you to use `get_current_price` instead.
     pub fn get_prev_price_unchecked(&self) -> (Price, UnixTimestamp) {
         (
             Price {
@@ -211,7 +213,7 @@ impl PriceFeed {
                 conf:  self.prev_conf,
                 expo:  self.expo,
             },
-            self.prev_timestamp,
+            self.prev_publish_time,
         )
     }
 }


### PR DESCRIPTION
Adds timestamp + previous price.

- Adds `get_prev_price_unchecked` to receive it.
- Also modifies Solana account struct to be the same as the oracle
- Bumps version of all packages as it is a breaking change.
