### PR TITLE
Update ser/de: prices to string + ids to hex string

### DIFF
--- a/examples/terra-contract/Cargo.toml
+++ b/examples/terra-contract/Cargo.toml
@@ -34,7 +34,7 @@ cosmwasm-storage = { version = "0.16.0" }
 cw-storage-plus = "0.8.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyth-sdk-terra = { version = "0.2.0", path = "../../pyth-sdk-terra" } # Remove path and use version only when you use this example on your own.
+pyth-sdk-terra = { version = "0.3.0-alpha", path = "../../pyth-sdk-terra" } # Remove path and use version only when you use this example on your own.
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }

--- a/examples/terra-contract/Cargo.toml
+++ b/examples/terra-contract/Cargo.toml
@@ -34,7 +34,7 @@ cosmwasm-storage = { version = "0.16.0" }
 cw-storage-plus = "0.8.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyth-sdk-terra = { version = "0.3.0-alpha", path = "../../pyth-sdk-terra" } # Remove path and use version only when you use this example on your own.
+pyth-sdk-terra = { version = "0.3.0", path = "../../pyth-sdk-terra" } # Remove path and use version only when you use this example on your own.
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }

--- a/examples/terra-contract/schema/fetch_price_response.json
+++ b/examples/terra-contract/schema/fetch_price_response.json
@@ -26,9 +26,7 @@
       "properties": {
         "conf": {
           "description": "Confidence Interval.",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
+          "type": "string"
         },
         "expo": {
           "description": "Exponent.",
@@ -37,8 +35,7 @@
         },
         "price": {
           "description": "Price.",
-          "type": "integer",
-          "format": "int64"
+          "type": "string"
         }
       }
     }

--- a/examples/terra-contract/schema/instantiate_msg.json
+++ b/examples/terra-contract/schema/instantiate_msg.json
@@ -8,16 +8,14 @@
   ],
   "properties": {
     "price_feed_id": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      },
-      "maxItems": 32,
-      "minItems": 32
+      "$ref": "#/definitions/Identifier"
     },
     "pyth_contract_addr": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "Identifier": {
       "type": "string"
     }
   }

--- a/examples/terra-contract/schema/state.json
+++ b/examples/terra-contract/schema/state.json
@@ -8,14 +8,7 @@
   ],
   "properties": {
     "price_feed_id": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      },
-      "maxItems": 32,
-      "minItems": 32
+      "$ref": "#/definitions/Identifier"
     },
     "pyth_contract_addr": {
       "$ref": "#/definitions/Addr"
@@ -24,6 +17,9 @@
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Identifier": {
       "type": "string"
     }
   }

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.3.1"
+version = "0.4.0-alpha"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.3.1" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.4.0-alpha" }
 
 [dev-dependencies]
 solana-client = "1.8.1"

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.4.0-alpha"
+version = "0.4.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.4.0-alpha" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.4.0" }
 
 [dev-dependencies]
 solana-client = "1.8.1"

--- a/pyth-sdk-solana/src/state.rs
+++ b/pyth-sdk-solana/src/state.rs
@@ -12,6 +12,10 @@ use bytemuck::{
     PodCastError,
     Zeroable,
 };
+use pyth_sdk::{
+    PriceIdentifier,
+    ProductIdentifier,
+};
 use solana_program::pubkey::Pubkey;
 use std::mem::size_of;
 
@@ -352,13 +356,13 @@ impl PriceAccount {
         }
 
         PriceFeed::new(
-            price_key.to_bytes(),
+            PriceIdentifier::new(price_key.to_bytes()),
             status,
             self.timestamp,
             self.expo,
             self.num,
             self.num_qt,
-            self.prod.val,
+            ProductIdentifier::new(self.prod.val),
             self.agg.price,
             self.agg.conf,
             self.ema_price.val,

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-contract"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 
 [features]
@@ -8,7 +8,7 @@ test-bpf = []
 no-entrypoint = []
 
 [dependencies]
-pyth-sdk-solana = { path = "../", version = "0.3.1" }
+pyth-sdk-solana = { path = "../", version = "0.4.0-alpha" }
 solana-program = "1.8.1"
 bytemuck = "1.7.2"
 borsh = "0.9"

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -8,7 +8,7 @@ test-bpf = []
 no-entrypoint = []
 
 [dependencies]
-pyth-sdk-solana = { path = "../", version = "0.4.0-alpha" }
+pyth-sdk-solana = { path = "../", version = "0.4.0" }
 solana-program = "1.8.1"
 bytemuck = "1.7.2"
 borsh = "0.9"

--- a/pyth-sdk-terra/Cargo.toml
+++ b/pyth-sdk-terra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-terra"
-version = "0.3.0-alpha"
+version = "0.3.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ readme = "README.md"
 cosmwasm-std = { version = "0.16.0" }
 cosmwasm-storage = { version = "0.16.0" }
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.4.0-alpha" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.4.0" }
 schemars = "0.8.1"
 
 [dev-dependencies]

--- a/pyth-sdk-terra/Cargo.toml
+++ b/pyth-sdk-terra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-terra"
-version = "0.2.0"
+version = "0.3.0-alpha"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ readme = "README.md"
 cosmwasm-std = { version = "0.16.0" }
 cosmwasm-storage = { version = "0.16.0" }
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.3.1" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.4.0-alpha" }
 schemars = "0.8.1"
 
 [dev-dependencies]

--- a/pyth-sdk-terra/schema/price_feed_response.json
+++ b/pyth-sdk-terra/schema/price_feed_response.json
@@ -16,6 +16,9 @@
     }
   },
   "definitions": {
+    "Identifier": {
+      "type": "string"
+    },
     "PriceFeed": {
       "description": "Represents a current aggregation price from pyth publisher feeds.",
       "type": "object",
@@ -38,20 +41,15 @@
       "properties": {
         "conf": {
           "description": "Confidence interval around the current aggregation price.",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
+          "type": "string"
         },
         "ema_conf": {
           "description": "Exponentially moving average confidence interval.",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
+          "type": "string"
         },
         "ema_price": {
           "description": "Exponentially moving average price.",
-          "type": "integer",
-          "format": "int64"
+          "type": "string"
         },
         "expo": {
           "description": "Price exponent.",
@@ -60,14 +58,11 @@
         },
         "id": {
           "description": "Unique identifier for this price.",
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "maxItems": 32,
-          "minItems": 32
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
         },
         "max_num_publishers": {
           "description": "Maximum number of allowed publishers that can contribute to a price.",
@@ -83,14 +78,11 @@
         },
         "prev_conf": {
           "description": "Confidence interval of previous aggregate with Trading status.",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
+          "type": "string"
         },
         "prev_price": {
           "description": "Price of previous aggregate with Trading status.",
-          "type": "integer",
-          "format": "int64"
+          "type": "string"
         },
         "prev_publish_time": {
           "description": "Publish time of previous aggregate with Trading status.",
@@ -99,19 +91,15 @@
         },
         "price": {
           "description": "The current aggregation price.",
-          "type": "integer",
-          "format": "int64"
+          "type": "string"
         },
         "product_id": {
           "description": "Product account key.",
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "maxItems": 32,
-          "minItems": 32
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
         },
         "publish_time": {
           "description": "Current price aggregation publish time",

--- a/pyth-sdk-terra/schema/query_msg.json
+++ b/pyth-sdk-terra/schema/query_msg.json
@@ -15,19 +15,17 @@
           ],
           "properties": {
             "id": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 32,
-              "minItems": 32
+              "$ref": "#/definitions/Identifier"
             }
           }
         }
       },
       "additionalProperties": false
     }
-  ]
+  ],
+  "definitions": {
+    "Identifier": {
+      "type": "string"
+    }
+  }
 }

--- a/pyth-sdk/Cargo.toml
+++ b/pyth-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk"
-version = "0.3.1"
+version = "0.4.0-alpha"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,6 +14,7 @@ readme = "README.md"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+hex = { version = "0.4.3", features = ["serde"] }
 borsh = "0.9"
 borsh-derive = "0.9.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/pyth-sdk/Cargo.toml
+++ b/pyth-sdk/Cargo.toml
@@ -19,3 +19,6 @@ borsh = "0.9"
 borsh-derive = "0.9.0"
 serde = { version = "1.0.136", features = ["derive"] }
 schemars = "0.8.8"
+
+[dev-dependencies]
+serde_json = "1.0.79"

--- a/pyth-sdk/Cargo.toml
+++ b/pyth-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk"
-version = "0.4.0-alpha"
+version = "0.4.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -53,6 +53,7 @@ impl Identifier {
 
 impl fmt::Debug for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("0x")?;
         f.write_str(&self.to_hex())
     }
 }
@@ -362,7 +363,7 @@ mod test {
         let id_str = format!("{:?}", id);
         assert_eq!(
             id_str,
-            "0a00000000000000000000000000000000000000000000000000000000000000"
+            "0x0a00000000000000000000000000000000000000000000000000000000000000"
         );
     }
 }

--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -53,15 +53,13 @@ impl Identifier {
 
 impl fmt::Debug for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("0x")?;
-        f.write_str(&self.to_hex())
+        write!(f, "0x{}", self.to_hex())
     }
 }
 
 impl fmt::Display for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("0x")?;
-        f.write_str(&self.to_hex())
+        write!(f, "0x{}", self.to_hex())
     }
 }
 

--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -58,6 +58,14 @@ impl fmt::Debug for Identifier {
     }
 }
 
+impl fmt::Display for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("0x")?;
+        f.write_str(&self.to_hex())
+    }
+}
+
+
 /// Consists of 32 bytes and it is currently based on largest Public Key size on various
 /// blockchains.
 pub type PriceIdentifier = Identifier;
@@ -361,6 +369,18 @@ mod test {
         id.0[0] = 10;
 
         let id_str = format!("{:?}", id);
+        assert_eq!(
+            id_str,
+            "0x0a00000000000000000000000000000000000000000000000000000000000000"
+        );
+    }
+
+    #[test]
+    pub fn test_identifier_display_fmt() {
+        let mut id = Identifier::default();
+        id.0[0] = 10;
+
+        let id_str = format!("{}", id);
         assert_eq!(
             id_str,
             "0x0a00000000000000000000000000000000000000000000000000000000000000"

--- a/pyth-sdk/src/price.rs
+++ b/pyth-sdk/src/price.rs
@@ -5,6 +5,8 @@ use borsh::{
 
 use schemars::JsonSchema;
 
+use crate::utils;
+
 // Constants for working with pyth's number representation
 const PD_EXPO: i32 = -9;
 const PD_SCALE: u64 = 1_000_000_000;
@@ -44,8 +46,12 @@ const MAX_PD_V_U64: u64 = (1 << 28) - 1;
 )]
 pub struct Price {
     /// Price.
+    #[serde(with = "utils::as_string")] // To ensure accuracy on conversion to json.
+    #[schemars(with = "String")]
     pub price: i64,
     /// Confidence Interval.
+    #[serde(with = "utils::as_string")]
+    #[schemars(with = "String")]
     pub conf:  u64,
     /// Exponent.
     pub expo:  i32,

--- a/pyth-sdk/src/utils.rs
+++ b/pyth-sdk/src/utils.rs
@@ -1,0 +1,32 @@
+/// This module helps serde to serialize deserialize some fields as String
+///
+/// The reason this is added is that `#[serde(with = "String")]` does not work
+/// because Borsh also implements serialize and deserialize functions and
+/// compiler cannot distinguish them.
+pub mod as_string {
+    use serde::de::Error;
+    use serde::{
+        Deserialize,
+        Deserializer,
+        Serializer,
+    };
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: std::fmt::Display,
+        S: Serializer,
+    {
+        serializer.collect_str(value)
+    }
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: std::str::FromStr,
+        D: Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        string
+            .parse()
+            .map_err(|_| D::Error::custom("Input was not valid"))
+    }
+}

--- a/pyth-sdk/src/utils.rs
+++ b/pyth-sdk/src/utils.rs
@@ -27,6 +27,6 @@ pub mod as_string {
         let string = String::deserialize(deserializer)?;
         string
             .parse()
-            .map_err(|_| D::Error::custom("Input was not valid"))
+            .map_err(|_| D::Error::custom("Input is not valid"))
     }
 }


### PR DESCRIPTION
There are multiple reasons for improving the serde. 

1. price values. Currently serde_json converts numbers to js number which is inaccurate for large prices. So we need to make them string. There is a custom converter here and the reason for it is documented.
2. Identifiers. Again in js side it is transferred to js array which is hard for people compared to hex. Also logging byte arrays is not easy. I chosed wrapping it in a tuple struct because the json schema will become simpler and in every place (such as terra sdk query body) this conversion will happen automatically. Also it adds some utilities for conversion to/from hex.

I will make the version final after receiving feedbacks and approvals.