### PR TITLE
Avoid using collect_str in as_string mod

### DIFF
--- a/pyth-sdk/Cargo.toml
+++ b/pyth-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pyth-sdk/src/utils.rs
+++ b/pyth-sdk/src/utils.rs
@@ -16,7 +16,7 @@ pub mod as_string {
         T: std::fmt::Display,
         S: Serializer,
     {
-        serializer.collect_str(value)
+        serializer.serialize_str(value.to_string().as_str())
     }
 
     pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>


### PR DESCRIPTION
The reason is that some serializers (serde_json_wasm in our case) does
not implement this function and raise
not implemented panic.

In future if we need no_std env we might need to change this.