### PR TITLE
Simplify Solana SDK README

### DIFF
--- a/pyth-sdk-solana/README.md
+++ b/pyth-sdk-solana/README.md
@@ -24,7 +24,7 @@ Applications can obtain the content of these accounts in two different ways:
 * On-chain programs should pass these accounts to the instructions that require price feeds.
 * Off-chain programs can access these accounts using the Solana RPC client (as in the [eth price example program](examples/eth_price.rs)).
 
-The pyth.network website can be used to identify the public keys of the various Pyth Network accounts (e.g., [Crypto.BTC/USD accounts](https://pyth.network/markets/#Crypto.BTC/USD)).
+To use the SDK, you will need to find the price feed account for the symbol you wish to consume. The [Pyth Network documentation](https://docs.pyth.network/consume-data/solana#price-feeds) explains how to do this. The public key of this account corresponds to the ID of the price feed.
 
 ### On-chain
 

--- a/pyth-sdk-solana/README.md
+++ b/pyth-sdk-solana/README.md
@@ -16,12 +16,10 @@ See [pyth-sdk-solana on crates.io](https://crates.io/crates/pyth-sdk-solana/) to
 
 ## Usage
 
-Pyth Network stores its price feeds in a collection of Solana accounts of various types:
-* Price accounts store the current price for a product
-* Product accounts store metadata about a product, such as its symbol (e.g., "BTC/USD").
-* Mapping accounts store a listing of all Pyth accounts
+### Price Feeds
 
-Most users of this SDK only need to access the content of price accounts; the other two account types are implementation details of the oracle.
+Pyth Network stores the data for it's price feeds in Solana accounts, called "price accounts".
+
 Applications can obtain the content of these accounts in two different ways:
 * On-chain programs should pass these accounts to the instructions that require price feeds.
 * Off-chain programs can access these accounts using the Solana RPC client (as in the [eth price example program](examples/eth_price.rs)).
@@ -65,29 +63,7 @@ let current_price: Price = price_feed.get_current_price().unwrap();
 println!("price: ({} +- {}) x 10^{}", current_price.price, current_price.conf, current_price.expo);
 ```
 
-## Low-Level Solana Account Structure
-
-> :warning: The Solana account structure is an internal API that is subject to change. Prefer to use `load_price_feed_*` when possible.
-
-This library also provides several `load_*` methods that allow users to translate the binary data in each account into an appropriate struct:
-
-```rust
-use pyth_sdk_solana::state::*;
-
-// replace with account data, either passed to on-chain program or from RPC node
-let price_account_data: Vec<u8> = ...;
-let price_account: &PriceAccount = load_price_account( &price_account_data ).unwrap();
-
-let product_account_data: Vec<u8> = ...;
-let product_account: &ProductAccount = load_product_account( &product_account_data ).unwrap();
-
-let mapping_account_data: Vec<u8> = ...;
-let mapping_account: &MappingAccount = load_mapping_account( &mapping_account_data ).unwrap();
-```
-
-For more information on the different types of Pyth accounts, see the [account structure documentation](https://docs.pyth.network/how-pyth-works/account-structure).
-
-## Off-chain Example Programs
+## Off-chain Example Program
 
 The example [eth_price](examples/eth_price.rs) program prints the product reference data and current price information for Pyth on Solana devnet.
 Run the following commands to try this example program:
@@ -107,35 +83,6 @@ price ........... 291958500000 x 10^-8
 conf ............ 163920000 x 10^-8
 ema_price ....... 291343470000 x 10^-8
 ema_conf ........ 98874533 x 10^-8
-```
-
-For [an example](examples/get_accounts.rs) of using Solana Account structure please run:
-```
-cargo run --example get_accounts
-```
-
-The output of this command is a listing of Pyth's accounts, such as:
-
-```
-product_account .. 6MEwdxe4g1NeAF9u6KDG14anJpFsVEa2cvr5H6iriFZ8
-  symbol.......... SRM/USD
-  asset_type...... Crypto
-  quote_currency.. USD
-  description..... SRM/USD
-  generic_symbol.. SRMUSD
-  base............ SRM
-  price_account .. 992moaMQKs32GKZ9dxi8keyM2bUmbrwBZpK4p2K6X5Vs
-    price ........ 7398000000
-    conf ......... 3200000
-    price_type ... price
-    exponent ..... -9
-    status ....... trading
-    corp_act ..... nocorpact
-    num_qt ....... 1
-    valid_slot ... 91340924
-    publish_slot . 91340925
-    ema_price .... 7426390900
-    ema_conf ..... 2259870
 ```
 
 ## Development


### PR DESCRIPTION
This PR removes the description of the account structure, which is an implementation detail, and adds a link to the pyth.network docs which explain how to look up the price feed IDs.

Eventually the website will show a definitive list of price feed IDs for each blockchain, but in the meantime this should be documented.