### PR TITLE
Use CW instead of Terra wherever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Key features of this SDK include:
 * Get the current price of over [50 products](https://pyth.network/markets/), including cryptocurrencies,
   US equities, forex and more.
 * Combine listed products to create new price feeds, e.g., for baskets of tokens or non-USD quote currencies.
-* Consume prices in Solana programs, Terra smart contracts, or off-chain applications.
+* Consume prices in Solana programs, CosmWasm smart contracts, or off-chain applications.
 
 Please see the [pyth.network documentation](https://docs.pyth.network/) for more information about pyth.network.
 
@@ -18,7 +18,7 @@ This repository is divided into several crates focused on specific use cases:
 1. [Pyth SDK](pyth-sdk) provides common data types and interfaces for that are shared across different blockchains.
 2. [Pyth SDK Solana](pyth-sdk-solana) provides an interface for reading Pyth price feeds in Solana programs.
    This crate may also be used in off-chain applications that read prices from the Solana blockchain.
-3. [Pyth SDK Terra](pyth-sdk-terra) provides an interface for reading Pyth price feeds in on-chain Terra contracts.
+3. [Pyth SDK CosmWasm](pyth-sdk-cw) provides an interface for reading Pyth price feeds in on-chain CosmWasm contracts.
 
 Please see the documentation for the relevant crate to get started using Pyth Network.
 

--- a/examples/cw-contract/Cargo.toml
+++ b/examples/cw-contract/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "example-terra-contract"
+name = "example-cw-contract"
 version = "0.1.0"
 authors = ["Ali Behjati <bahjatia@gmail.com>"]
 edition = "2018"

--- a/examples/cw-contract/Developing.md
+++ b/examples/cw-contract/Developing.md
@@ -19,11 +19,11 @@ rustup target list --installed
 rustup target add wasm32-unknown-unknown
 ```
 
-This example uses relative paths in `Cargo.toml`; you must remove any `path` components within `Cargo.toml` dependencies if you intend to compile this code outside of the `pyth-sdk-terra` repository, otherwise this will fail to compile. For example:
+This example uses relative paths in `Cargo.toml`; you must remove any `path` components within `Cargo.toml` dependencies if you intend to compile this code outside of the `pyth-sdk-cw` repository, otherwise this will fail to compile. For example:
 
 ```diff
-- pyth-sdk-terra = { version = "0.4.0", path = "../../pyth-sdk-terra" }
-+ pyth-sdk-terra = { version = "0.4.0" }
+- pyth-sdk-cw = { version = "0.1.0", path = "../../pyth-sdk-cw" }
++ pyth-sdk-cw = { version = "0.1.0" }
 ```
 
 ## Compiling
@@ -32,7 +32,7 @@ After changing the contract, make sure you can compile and run it before
 making any changes. Go into the repository and do:
 
 ```sh
-# this will produce a wasm build in ./target/wasm32-unknown-unknown/release/exxamle_terra_contract.wasm
+# this will produce a wasm build in ./target/wasm32-unknown-unknown/release/example_cw_contract.wasm
 cargo build --release --target wasm32-unknown-unknown
 ```
 ## Generating JSON Schema

--- a/examples/cw-contract/README.md
+++ b/examples/cw-contract/README.md
@@ -1,11 +1,11 @@
-# Pyth SDK Example Contract for Terra
+# Pyth SDK Example Contract for CosmWasm
 
 This repository contains an example contract that demonstrates how to read the Pyth price from the Pyth on-chain contract.
 The example [contract](src/contract.rs) has two functions:
 
 * `instantiate` sets the Pyth contract address and price feed id that the contract uses.
   This function is intended to be called once when the contract is deployed.
-  See the [Terra SDK README](../../pyth-sdk-terra/README.md) for the list of possible price feed ids.
+  See the [CosmWasm SDK README](../../pyth-sdk-cw/README.md) for the list of possible price feed ids.
 * `query` queries the Pyth contract to get the current price for the configured price feed id.
 
 ## Testnet Demo
@@ -52,7 +52,7 @@ If you would like to deploy a changed version of this contract, the process cons
 ### Build WASM
 
 See the [Developing instructions](Developing.md) for how to build the WASM for the contract.
-The instructions in that document will build a file called `example_terra_contract.wasm` under the `artifacts/` directory.
+The instructions in that document will build a file called `example_cw_contract.wasm` under the `artifacts/` directory.
 
 ### Upload and Instantiate Contract
 
@@ -62,7 +62,7 @@ You can run that script on the built WASM file as follows:
 ``` sh
 cd tools/
 npm install
-npm run deploy -- --network testnet --artifact ../artifacts/example_terra_contract.wasm --mnemonic "..." --instantiate
+npm run deploy -- --network testnet --artifact ../artifacts/example_cw_contract.wasm --mnemonic "..." --instantiate
 ```
 
 This command will deploy the contract to `testnet` and sets its owner to the wallet with the provided `mnemonic`.
@@ -70,7 +70,7 @@ Note that you have to populate the `--mnemonic` flag with the seedphrase for a v
 
 If successful, the output should look like:
 ```
-Storing WASM: ../artifacts/example_terra_contract.wasm (183749 bytes)
+Storing WASM: ../artifacts/example_cw_contract.wasm (183749 bytes)
 Deploy fee:  44682uluna
 Code ID:  53199
 Instantiating a contract
@@ -93,14 +93,14 @@ npm run query -- --network testnet --contract <contract address>
 You can also migrate an existing contract by passing the `--migrate --contract terra123456xyzqwe..` arguments to the deploy command:
 
 ``` sh
-npm run deploy -- --network testnet --artifact ../artifacts/example_terra_contract.wasm --mnemonic "..." --migrate --contract "terra123..."
+npm run deploy -- --network testnet --artifact ../artifacts/example_cw_contract.wasm --mnemonic "..." --migrate --contract "terra123..."
 ```
 
 This command will replace the code for the given contract with the specified WASM artifact.
 If successful, the output should look like:
 
 ```
-Storing WASM: ../artifacts/example_terra_contract.wasm (183749 bytes)
+Storing WASM: ../artifacts/example_cw_contract.wasm (183749 bytes)
 Deploy fee:  44682uluna
 Code ID:  53227
 Sleeping for 10 seconds for store transaction to finalize.
@@ -111,6 +111,6 @@ Contract terra123456789yelw23uh22nadqlyjvtl7s5527er97 code_id successfully updat
 ### Troubleshooting
 
 When deploying the contract, you may encounter gateway timeout or account sequence mismatch errors.
-If this happens, check terra finder to determine if your transaction succeeded -- sometimes transactions succeed despite timing out.
+If this happens, check Terra Finder to determine if your transaction succeeded -- sometimes transactions succeed despite timing out.
 Note that the deployment script submits multiple transactions.
 If any of them fails, simply rerun the entire script; there is no problem re-running the successful transactions.

--- a/examples/cw-contract/examples/schema.rs
+++ b/examples/cw-contract/examples/schema.rs
@@ -7,13 +7,13 @@ use cosmwasm_schema::{
     schema_for,
 };
 
-use example_terra_contract::msg::{
+use example_cw_contract::msg::{
     ExecuteMsg,
     FetchPriceResponse,
     InstantiateMsg,
     QueryMsg,
 };
-use example_terra_contract::state::State;
+use example_cw_contract::state::State;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/examples/cw-contract/src/state.rs
+++ b/examples/cw-contract/src/state.rs
@@ -10,9 +10,9 @@ use pyth_sdk_cw::PriceIdentifier;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
-    // Available price feeds and their ids are listed in pyth-sdk-terra Readme.
+    // Available price feeds and their ids are listed in pyth-sdk-cw Readme.
     pub price_feed_id:      PriceIdentifier,
-    // Contract address of Pyth in different networks are listed in pyth-sdk-terra Readme.
+    // Contract address of Pyth in different networks are listed in pyth-sdk-cw Readme.
     pub pyth_contract_addr: Addr,
 }
 

--- a/pyth-sdk-cw/Cargo.toml
+++ b/pyth-sdk-cw/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 homepage = "https://pyth.network"
 repository = "https://github.com/pyth-network/pyth-sdk-rs"
 description = "pyth price oracle data structures and example usage"
-keywords = [ "pyth", "terra", "oracle" ]
+keywords = [ "pyth", "cw", "cosmwasm", "oracle" ]
 readme = "README.md"
 
 [dependencies]

--- a/pyth-sdk-cw/README.md
+++ b/pyth-sdk-cw/README.md
@@ -1,7 +1,7 @@
 # Pyth Network CosmWasm SDK
 
 This crate provides utilities for reading price feeds from the [pyth.network](https://pyth.network/) oracle on the CosmWasm ecosystem.
-It also includes an [example contract](../examples/terra-contract/) demonstrating how to read price feeds from on-chain CosmWasm applications.
+It also includes an [example contract](../examples/cw-contract/) demonstrating how to read price feeds from on-chain CosmWasm applications.
 
 ## Installation
 

--- a/pyth-sdk/README.md
+++ b/pyth-sdk/README.md
@@ -1,7 +1,7 @@
 # Pyth Network Common Rust SDK
 
 This crate contains Pyth Network data structures that are shared across all Rust-based consumers of Pyth Network data.
-This crate is typically used in combination with a platform-specific crate such as [pyth-sdk-solana](../pyth-sdk-solana) or [pyth-sdk-terra](../pyth-sdk-terra).
+This crate is typically used in combination with a platform-specific crate such as [pyth-sdk-solana](../pyth-sdk-solana) or [pyth-sdk-cw](../pyth-sdk-cw).
 
 ## Usage
 


### PR DESCRIPTION
There are still some places that Terra is mentioned such as
deploy scripts and available networks.
We should update them later.