### PR TITLE
Replace get_prev_price with better methods

### DIFF
--- a/examples/cw-contract/Cargo.toml
+++ b/examples/cw-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "example-cw-contract"
 version = "0.1.0"
-authors = ["Ali Behjati <bahjatia@gmail.com>"]
+authors = ["Pyth Data Foundation"]
 edition = "2018"
 
 exclude = [
@@ -34,7 +34,7 @@ cosmwasm-storage = { version = "1.0.0" }
 cw-storage-plus = "0.13.4"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyth-sdk-cw = { version = "0.1.0", path = "../../pyth-sdk-cw" } # Remove path and use version only when you use this example on your own.
+pyth-sdk-cw = { version = "0.2.0", path = "../../pyth-sdk-cw" } # Remove path and use version only when you use this example on your own.
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/pyth-sdk-cw/Cargo.toml
+++ b/pyth-sdk-cw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-cw"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ readme = "README.md"
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.4.1" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.5.0" }
 schemars = "0.8.1"
 
 [dev-dependencies]

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.4.0" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.5.0" }
 
 [dev-dependencies]
 solana-client = "1.8.1, < 1.11"

--- a/pyth-sdk-solana/src/lib.rs
+++ b/pyth-sdk-solana/src/lib.rs
@@ -19,6 +19,7 @@ use state::load_price_account;
 pub use pyth_sdk::{
     Price,
     PriceFeed,
+    PriceIdentifier,
     PriceStatus,
     ProductIdentifier,
 };

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -8,7 +8,7 @@ test-bpf = []
 no-entrypoint = []
 
 [dependencies]
-pyth-sdk-solana = { path = "../", version = "0.4.0" }
+pyth-sdk-solana = { path = "../", version = "0.5.0" }
 solana-program = "1.8.1, < 1.11" # Currently latest Solana 1.11 crate can't build bpf: https://github.com/solana-labs/solana/issues/26188
 bytemuck = "1.7.2"
 borsh = "0.9"

--- a/pyth-sdk-solana/test-contract/tests/stale_price.rs
+++ b/pyth-sdk-solana/test-contract/tests/stale_price.rs
@@ -55,11 +55,7 @@ async fn test_price_stale() {
     price.agg.status = PriceStatus::Trading;
     price.agg.pub_slot = 1000 - VALID_SLOT_PERIOD - 1;
 
-    #[cfg(feature = "test-bpf")] // Only in BPF the clock check is performed
     let expected_status = PriceStatus::Unknown;
-
-    #[cfg(not(feature = "test-bpf"))]
-    let expected_status = PriceStatus::Trading;
 
     test_instr_exec_ok(instruction::price_status_check(&price, expected_status)).await;
 }

--- a/pyth-sdk/Cargo.toml
+++ b/pyth-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
The reason `current_time` is an argument there is that the SDK is chain agnostic and there is no notion of system current time.

This PR will fix #14 and #29 too and bumps the version.