### PR TITLE
Replace pyth_sdk_solana::AccKey with solana_program::pubkey::Pubkey

### DIFF
--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pyth-sdk-solana/examples/get_accounts.rs
+++ b/pyth-sdk-solana/examples/get_accounts.rs
@@ -51,8 +51,7 @@ fn main() {
 
         // iget and print each Product in Mapping directory
         let mut i = 0;
-        for prod_akey in &map_acct.products {
-            let prod_pkey = Pubkey::new(&prod_akey.val);
+        for prod_pkey in &map_acct.products {
             let prod_data = clnt.get_account_data(&prod_pkey).unwrap();
             let prod_acct = load_product_account(&prod_data).unwrap();
 
@@ -65,8 +64,8 @@ fn main() {
             }
 
             // print all Prices that correspond to this Product
-            if prod_acct.px_acc.is_valid() {
-                let mut px_pkey = Pubkey::new(&prod_acct.px_acc.val);
+            if prod_acct.px_acc != Pubkey::default() {
+                let mut px_pkey = prod_acct.px_acc;
                 loop {
                     let price_data = clnt.get_account_data(&px_pkey).unwrap();
                     let price_account = load_price_account(&price_data).unwrap();
@@ -120,8 +119,8 @@ fn main() {
                     }
 
                     // go to next price account in list
-                    if price_account.next.is_valid() {
-                        px_pkey = Pubkey::new(&price_account.next.val);
+                    if price_account.next != Pubkey::default() {
+                        px_pkey = price_account.next;
                     } else {
                         break;
                     }
@@ -135,9 +134,9 @@ fn main() {
         }
 
         // go to next Mapping account in list
-        if !map_acct.next.is_valid() {
+        if map_acct.next == Pubkey::default() {
             break;
         }
-        akey = Pubkey::new(&map_acct.next.val);
+        akey = map_acct.next;
     }
 }

--- a/pyth-sdk-solana/src/state.rs
+++ b/pyth-sdk-solana/src/state.rs
@@ -358,19 +358,6 @@ impl PriceAccount {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-struct AccKeyU64 {
-    pub val: [u64; 4],
-}
-
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for AccKeyU64 {
-}
-
-#[cfg(target_endian = "little")]
-unsafe impl Pod for AccKeyU64 {
-}
-
 fn load<T: Pod>(data: &[u8]) -> Result<&T, PodCastError> {
     let size = size_of::<T>();
     if data.len() >= size {

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -8,7 +8,7 @@ test-bpf = []
 no-entrypoint = []
 
 [dependencies]
-pyth-sdk-solana = { path = "../", version = "0.5.0" }
+pyth-sdk-solana = { path = "../", version = "0.6.0" }
 solana-program = "1.8.1, < 1.11" # Currently latest Solana 1.11 crate can't build bpf: https://github.com/solana-labs/solana/issues/26188
 bytemuck = "1.7.2"
 borsh = "0.9"


### PR DESCRIPTION
When using `pyth-sdk-solana` in a project that also uses `solana-sdk` , the fact that our account keys are represented using `pyth_sdk_solana::state::AccKey` instead of `solana_sdk::pubkey::Pubkey` is quite unergonomic. Comparing a `AccKey` to a `Pubkey` requires converting them to be the same type, so code becomes littered with calls to conversion functions.

This PR changes `pyth-sdk-solana` to use `solana_program::pubkey::Pubkey` for account keys.

Bumping the major version as this is a breaking change.