### PR TITLE
Update the price schema

### DIFF
--- a/pyth-sdk-cw/schema/price_feed_response.json
+++ b/pyth-sdk-cw/schema/price_feed_response.json
@@ -118,12 +118,35 @@
     },
     "PriceStatus": {
       "description": "Represents availability status of a price feed.",
-      "type": "string",
-      "enum": [
-        "Unknown",
-        "Trading",
-        "Halted",
-        "Auction"
+      "oneOf": [
+        {
+          "description": "The price feed is not currently updating for an unknown reason.",
+          "type": "string",
+          "enum": [
+            "Unknown"
+          ]
+        },
+        {
+          "description": "The price feed is updating as expected.",
+          "type": "string",
+          "enum": [
+            "Trading"
+          ]
+        },
+        {
+          "description": "The price feed is not currently updating because trading in the product has been halted.",
+          "type": "string",
+          "enum": [
+            "Halted"
+          ]
+        },
+        {
+          "description": "The price feed is not currently updating because an auction is setting the price.",
+          "type": "string",
+          "enum": [
+            "Auction"
+          ]
+        }
       ]
     }
   }


### PR DESCRIPTION
This is happening because we are not storing a lock file and apparently a newer version of a packaged changes the output of our schema generation code.

The reason for not having lock file in git is that lib crates don't have lock files at all. Not having it in github allows us to catch problems that could happen for downstream consumers. However, this particular one, would not had any impact on downstream consumers.

The schema change itself is very weird and strange, the old one seems to be more accurate semantically. 
More context after looking deeper:

It’s using `cosmwasm-schema` which uses `schemars` to generate it. It seems that they have [this PR](https://github.com/GREsau/schemars/pull/152) that changed it (as a minor version upgrade) and is the exact root cause of our problem. They have made the change to handle descriptions for each enum type :exploding_head: