### PR TITLE
Remove custom toolchain setup (default is stable)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -32,13 +25,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -50,13 +36,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
 
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:

--- a/.github/workflows/pyth-sdk-cw.yml
+++ b/.github/workflows/pyth-sdk-cw.yml
@@ -33,14 +33,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
-          components: clippy
-
       - name: Generate Schema
         run: cargo run --example schema
 

--- a/.github/workflows/pyth-sdk-example-cw-contract.yml
+++ b/.github/workflows/pyth-sdk-example-cw-contract.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.58.1
+          toolchain: stable
           target: wasm32-unknown-unknown
           override: true
 
@@ -43,14 +43,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
-          components: clippy
 
       - name: Generate Schema
         run: cargo run --example schema

--- a/.github/workflows/pyth-sdk.yml
+++ b/.github/workflows/pyth-sdk.yml
@@ -35,14 +35,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
-          components: clippy
-
       - name: Generate Schema
         run: cargo run --example schema
 


### PR DESCRIPTION
Apparently a minor/patch upgrade in cosmwasm does not support slightly older version of rust. Removing all custom rust setups in our CI to fix the issue.

p.s: You can find more detail on [the issue](https://github.com/CosmWasm/cosmwasm/issues/1462) I created in cosmwasm repo mentioning it.