### PR TITLE
Relax solana version to be a range

### DIFF
--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "pyth", "solana", "oracle" ]
 readme = "README.md"
 
 [dependencies]
-solana-program = "1.10.40"
+solana-program = ">= 1.10, < 1.14"
 borsh = "0.9"
 borsh-derive = "0.9.0"
 bytemuck = "1.7.2"
@@ -22,8 +22,8 @@ serde = { version = "1.0.136", features = ["derive"] }
 pyth-sdk = { path = "../pyth-sdk", version = "0.6.1" }
 
 [dev-dependencies]
-solana-client = "1.10.40"
-solana-sdk = "1.10.40"
+solana-client = ">= 1.10, < 1.14"
+solana-sdk = ">= 1.10, < 1.14"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "pyth", "solana", "oracle" ]
 readme = "README.md"
 
 [dependencies]
-solana-program = ">= 1.10, < 1.14"
+solana-program = ">= 1.10, < 1.15"
 borsh = "0.9"
 borsh-derive = "0.9.0"
 bytemuck = "1.7.2"
@@ -22,8 +22,8 @@ serde = { version = "1.0.136", features = ["derive"] }
 pyth-sdk = { path = "../pyth-sdk", version = "0.6.1" }
 
 [dev-dependencies]
-solana-client = ">= 1.10, < 1.14"
-solana-sdk = ">= 1.10, < 1.14"
+solana-client = ">= 1.10, < 1.15"
+solana-sdk = ">= 1.10, < 1.15"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
This provides the benefit of less dependency version clashes when users might have another dependency that has pinned its solana-* dependencies.

Ran unit tests on 1.11 and 1.13.

Closes #79 