### PR TITLE
Adapt the Solana best-practice example to the new api + fix CI

### DIFF
--- a/.github/workflows/pyth-sdk-solana.yml
+++ b/.github/workflows/pyth-sdk-solana.yml
@@ -34,7 +34,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libudev-dev
     - name: Install Solana Binaries
       run: |
-        sh -c "$(curl -sSfL https://release.solana.com/v1.13.3/install)"
+        sh -c "$(curl -sSfL https://release.solana.com/v1.14.7/install)"
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/pyth-sdk-solana.yml
+++ b/.github/workflows/pyth-sdk-solana.yml
@@ -34,6 +34,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libudev-dev
     - name: Install Solana Binaries
       run: |
+        # Installing 1.14.x cli tools to have sbf instead of bpf. bpf does not work anymore.
         sh -c "$(curl -sSfL https://release.solana.com/v1.14.7/install)"
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Build

--- a/.github/workflows/pyth-sdk-solana.yml
+++ b/.github/workflows/pyth-sdk-solana.yml
@@ -34,7 +34,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libudev-dev
     - name: Install Solana Binaries
       run: |
-        sh -c "$(curl -sSfL https://release.solana.com/v1.10.40/install)"
+        sh -c "$(curl -sSfL https://release.solana.com/v1.13.3/install)"
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Build
       run: cargo build --verbose

--- a/examples/sol-contract/Cargo.toml
+++ b/examples/sol-contract/Cargo.toml
@@ -12,7 +12,3 @@ borsh = "0.9"
 arrayref = "0.3.6"
 solana-program = "1.10.40"
 pyth-sdk-solana = { path = "../../pyth-sdk-solana", version = "0.6.1" }
-
-[dev-dependencies]
-solana-sdk = "1.10.40"
-solana-client = "1.10.40"

--- a/examples/sol-contract/Cargo.toml
+++ b/examples/sol-contract/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 borsh = "0.9"
 arrayref = "0.3.6"
-solana-program = "1.10.40"
+solana-program = "=1.10.40"
 pyth-sdk-solana = { path = "../../pyth-sdk-solana", version = "0.6.1" }

--- a/examples/sol-contract/Cargo.toml
+++ b/examples/sol-contract/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 borsh = "0.9"
 arrayref = "0.3.6"
-solana-program = "=1.10.40"
+solana-program = "=1.13.3"
 pyth-sdk-solana = { path = "../../pyth-sdk-solana", version = "0.6.1" }

--- a/examples/sol-contract/README.md
+++ b/examples/sol-contract/README.md
@@ -17,7 +17,8 @@ Pyth SDK is used in the `Loan2Value` instruction in `src/processor.rs`.
 For the loan, the code first reads the unit price from the Pyth oracle.
 ```rust
 let feed1 = load_price_feed_from_account_info(pyth_loan_account)?;
-let result1 = feed1.get_current_price().ok_or(ProgramError::Custom(3))?;
+let current_timestamp1 = Clock::get()?.unix_timestamp;
+let result1 = feed1.get_price_no_older_than(current_timestamp1, 60).ok_or(ProgramError::Custom(3))?;
 ```
 
 And then calculate the loan value given the quantity of the loan.

--- a/examples/sol-contract/README.md
+++ b/examples/sol-contract/README.md
@@ -49,5 +49,5 @@ We assume that you have installed `cargo`, `solana`, `npm` and `node`.
 # Deploy the example contract
 > scripts/deploy.sh
 # Invoke the example contract
-> scripts/invoke.ts
+> scripts/invoke.sh
 ```

--- a/examples/sol-contract/src/processor.rs
+++ b/examples/sol-contract/src/processor.rs
@@ -8,11 +8,11 @@ use solana_program::account_info::{
 };
 use solana_program::entrypoint::ProgramResult;
 use solana_program::msg;
-use solana_program::sysvar::Sysvar;
-use solana_program::sysvar::clock::Clock;
 use solana_program::program_error::ProgramError;
 use solana_program::program_memory::sol_memcpy;
 use solana_program::pubkey::Pubkey;
+use solana_program::sysvar::clock::Clock;
+use solana_program::sysvar::Sysvar;
 
 use borsh::{
     BorshDeserialize,
@@ -87,7 +87,9 @@ pub fn process_instruction(
             // https://docs.pyth.network/consume-data/best-practices
             let feed1 = load_price_feed_from_account_info(pyth_loan_account)?;
             let current_timestamp1 = Clock::get()?.unix_timestamp;
-            let result1 = feed1.get_price_no_older_than(current_timestamp1, 60).ok_or(ProgramError::Custom(3))?;
+            let result1 = feed1
+                .get_price_no_older_than(current_timestamp1, 60)
+                .ok_or(ProgramError::Custom(3))?;
             let loan_max_price = result1
                 .price
                 .checked_add(result1.conf as i64)
@@ -107,7 +109,9 @@ pub fn process_instruction(
             // https://docs.pyth.network/consume-data/best-practices
             let feed2 = load_price_feed_from_account_info(pyth_collateral_account)?;
             let current_timestamp2 = Clock::get()?.unix_timestamp;
-            let result2 = feed2.get_price_no_older_than(current_timestamp2, 60).ok_or(ProgramError::Custom(3))?;
+            let result2 = feed2
+                .get_price_no_older_than(current_timestamp2, 60)
+                .ok_or(ProgramError::Custom(3))?;
             let collateral_min_price = result2
                 .price
                 .checked_sub(result2.conf as i64)

--- a/examples/sol-contract/src/processor.rs
+++ b/examples/sol-contract/src/processor.rs
@@ -8,6 +8,8 @@ use solana_program::account_info::{
 };
 use solana_program::entrypoint::ProgramResult;
 use solana_program::msg;
+use solana_program::sysvar::Sysvar;
+use solana_program::sysvar::clock::Clock;
 use solana_program::program_error::ProgramError;
 use solana_program::program_memory::sol_memcpy;
 use solana_program::pubkey::Pubkey;
@@ -84,7 +86,8 @@ pub fn process_instruction(
             // Here is more explanation on confidence interval in Pyth:
             // https://docs.pyth.network/consume-data/best-practices
             let feed1 = load_price_feed_from_account_info(pyth_loan_account)?;
-            let result1 = feed1.get_current_price().ok_or(ProgramError::Custom(3))?;
+            let current_timestamp1 = Clock::get()?.unix_timestamp;
+            let result1 = feed1.get_price_no_older_than(current_timestamp1, 60).ok_or(ProgramError::Custom(3))?;
             let loan_max_price = result1
                 .price
                 .checked_add(result1.conf as i64)
@@ -103,7 +106,8 @@ pub fn process_instruction(
             // Here is more explanation on confidence interval in Pyth:
             // https://docs.pyth.network/consume-data/best-practices
             let feed2 = load_price_feed_from_account_info(pyth_collateral_account)?;
-            let result2 = feed2.get_current_price().ok_or(ProgramError::Custom(3))?;
+            let current_timestamp2 = Clock::get()?.unix_timestamp;
+            let result2 = feed2.get_price_no_older_than(current_timestamp2, 60).ok_or(ProgramError::Custom(3))?;
             let collateral_min_price = result2
                 .price
                 .checked_sub(result2.conf as i64)

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -9,7 +9,7 @@ no-entrypoint = []
 
 [dependencies]
 pyth-sdk-solana = { path = "../", version = "0.6.1" }
-solana-program = "1.10.40"
+solana-program = "=1.10.40"
 bytemuck = "1.7.2"
 borsh = "0.9"
 borsh-derive = "0.9.0"

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -9,15 +9,15 @@ no-entrypoint = []
 
 [dependencies]
 pyth-sdk-solana = { path = "../", version = "0.6.1" }
-solana-program = "=1.10.40"
+solana-program = "=1.13.3"
 bytemuck = "1.7.2"
 borsh = "0.9"
 borsh-derive = "0.9.0"
 
 [dev-dependencies]
-solana-program-test = "1.10.40"
-solana-client = "1.10.40"
-solana-sdk = "1.10.40"
+solana-program-test = "=1.13.3"
+solana-client = "=1.13.3"
+solana-sdk = "=1.13.3"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
Fixes #84 

This change:
- Updates the example to use the latest api
- Pins Solana rust dependencies on the Solana example and test contract to 1.13.3 (latest released Solana mainnet)
- Uses Solana cli tools of v1.14.7 that have sbf instead of bpf. It seems that since bpf is outdated, for whatever reason, crates.io index cannot detect a suitable dependency for `time` that matches the flags/architecture. This change solves that problem.