### PR TITLE
Adapt to pyth-sdk-solana interface change in Anchor example

### DIFF
--- a/examples/sol-anchor-contract/Anchor.toml
+++ b/examples/sol-anchor-contract/Anchor.toml
@@ -1,5 +1,5 @@
 [programs.devnet]
-example_sol_anchor_contract = "Fwn1fCmbjd8d95hxY9NUUr5Xa7D13khveMnmCUFdd3ah"
+example_sol_anchor_contract = "9azQ2ePzPvMPQgHric53kdSNmwjVM5KijDE4ANFCE9D4"
 
 [provider]
 cluster = "devnet"

--- a/examples/sol-anchor-contract/README.md
+++ b/examples/sol-anchor-contract/README.md
@@ -26,5 +26,5 @@ We assume that you have installed `anchor`, `npm` and `yarn`.
 
 # Install the client dependencies and invoke this program
 > anchor run install
-> anchor run invoke
+> anchor run test
 ```

--- a/examples/sol-anchor-contract/programs/example-sol-anchor-contract/src/lib.rs
+++ b/examples/sol-anchor-contract/programs/example-sol-anchor-contract/src/lib.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use solana_program::account_info::AccountInfo;
 use pyth_sdk_solana::load_price_feed_from_account_info;
 
-declare_id!("Fwn1fCmbjd8d95hxY9NUUr5Xa7D13khveMnmCUFdd3ah");
+declare_id!("9azQ2ePzPvMPQgHric53kdSNmwjVM5KijDE4ANFCE9D4");
 
 #[account]
 pub struct AdminConfig {
@@ -54,7 +54,9 @@ pub mod example_sol_anchor_contract {
         // https://docs.pyth.network/consume-data/best-practices
         let feed1 = load_price_feed_from_account_info(pyth_loan_account)
             .map_err(|_x| error!(ErrorCode::PythError))?;
-        let result1 = feed1.get_current_price()
+        let current_timestamp1 = Clock::get()?.unix_timestamp;
+        let result1 = feed1
+            .get_price_no_older_than(current_timestamp1, 60)
             .ok_or(ErrorCode::PythOffline)?;
         let loan_max_price = result1
             .price
@@ -75,7 +77,9 @@ pub mod example_sol_anchor_contract {
         // https://docs.pyth.network/consume-data/best-practices
         let feed2 = load_price_feed_from_account_info(pyth_collateral_account)
                         .map_err(|_x| error!(ErrorCode::PythError))?;
-        let result2 = feed2.get_current_price()
+        let current_timestamp2 = Clock::get()?.unix_timestamp;
+        let result2 = feed2
+            .get_price_no_older_than(current_timestamp2, 60)
             .ok_or(ErrorCode::PythOffline)?;
         let collateral_min_price = result2
             .price

--- a/examples/sol-anchor-contract/scripts/test.ts
+++ b/examples/sol-anchor-contract/scripts/test.ts
@@ -26,7 +26,7 @@ try {
 try {
     assert(programId.equals(programKey.publicKey));
 } catch (error) {
-    throw new Error("Please make sure you have the same program address inAnchor.toml and program_address.json");
+    throw new Error("Please make sure you have the same program address in Anchor.toml and program_address.json");
 }
 
 it("Initialize the config.", async () => {


### PR DESCRIPTION
The Anchor example fails to compile due to the interface change in pyth-sdk-solana. Fixing the issue in a way similar to the solana example without Anchor.