### PR TITLE
Update CW SDK and example contract

### DIFF
--- a/examples/cw-contract/Cargo.toml
+++ b/examples/cw-contract/Cargo.toml
@@ -34,7 +34,8 @@ cosmwasm-storage = { version = "1.0.0" }
 cw-storage-plus = "0.13.4"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyth-sdk-cw = { version = "0.3.0", path = "../../pyth-sdk-cw" } # Remove path and use version only when you use this example on your own.
+pyth-sdk-cw = { version = "0.4.0", path = "../../pyth-sdk-cw" } # Remove path and use version only when you use this example on your own.
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
+pyth-sdk-cw = { version = "0.4.0", path = "../../pyth-sdk-cw", features = ["test-utils"] } # Remove path and use version only when you use this example on your own.

--- a/examples/cw-contract/Developing.md
+++ b/examples/cw-contract/Developing.md
@@ -75,7 +75,7 @@ docker run --rm -v "$(pwd)":/code \
   cosmwasm/rust-optimizer-arm64:0.12.6
 ```
 
-You must mount the contract code to `/code`. You can use a absolute path instead
+You must mount the contract code to `/code`. You can use an absolute path instead
 of `$(pwd)` if you don't want to `cd` to the directory first. The other two
 volumes are nice for speedup. Mounting `/code/target` in particular is useful
 to avoid docker overwriting your local dev files with root permissions.

--- a/examples/cw-contract/src/contract.rs
+++ b/examples/cw-contract/src/contract.rs
@@ -106,3 +106,101 @@ fn query_fetch_price(deps: Deps, env: Env) -> StdResult<FetchPriceResponse> {
         ema_price,
     })
 }
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+    use std::time::Duration;
+    use cosmwasm_std::{Coin, Timestamp, WasmQuery};
+    use {
+        super::*,
+        cosmwasm_std::{
+            from_binary,
+            testing::{
+                mock_dependencies,
+                mock_env,
+                MockApi,
+                MockQuerier,
+                MockStorage,
+            },
+            Addr,
+            OwnedDeps,
+            QuerierResult,
+            SystemError,
+            SystemResult,
+        },
+    };
+    use pyth_sdk_cw::{Price, PriceFeed, PriceIdentifier, UnixTimestamp};
+    use pyth_sdk_cw::test_utils::{MockPyth};
+
+    // Dummy contract address for testing.
+    // For real deployments, see list of contract addresses here https://docs.pyth.network/pythnet-price-feeds/cosmwasm
+    const PYTH_CONTRACT_ADDR: &str = "pyth_contract_addr";
+    // For real deployments, see list of price feed ids here https://pyth.network/developers/price-feed-ids
+    const PRICE_ID: &str = "63f341689d98a12ef60a5cff1d7f85c70a9e17bf1575f0e7c0b2512d48b1c8b3";
+
+    fn default_state() -> State {
+        State {
+            pyth_contract_addr:   Addr::unchecked(PYTH_CONTRACT_ADDR),
+            price_feed_id:   PriceIdentifier::from_hex(PRICE_ID).unwrap(),
+        }
+    }
+
+    fn setup_test(state: &State, mock_pyth: &MockPyth, block_timestamp: UnixTimestamp) -> (OwnedDeps<MockStorage, MockApi, MockQuerier>, Env) {
+        let mut dependencies = mock_dependencies();
+
+        let mock_pyth_copy = (*mock_pyth).clone();
+        dependencies
+          .querier
+          .update_wasm(move |x| handle_wasm_query(&mock_pyth_copy, x));
+
+        STATE.save(dependencies.as_mut().storage, state).unwrap();
+
+        let mut env = mock_env();
+        env.block.time = Timestamp::from_seconds(u64::try_from(block_timestamp).unwrap());
+
+        (dependencies, env)
+    }
+
+    // Create a handler like this in your test to handle pyth queries. If needed, other contracts
+    // can be configured in this handler via additional cases.
+    fn handle_wasm_query(pyth: &MockPyth, wasm_query: &WasmQuery) -> QuerierResult {
+        match wasm_query {
+            WasmQuery::Smart { contract_addr, msg } if *contract_addr == PYTH_CONTRACT_ADDR => {
+                pyth.handle_wasm_query(msg)
+            }
+            WasmQuery::Smart { contract_addr, .. } => {
+                SystemResult::Err(SystemError::NoSuchContract {
+                    addr: contract_addr.clone(),
+                })
+            }
+            WasmQuery::Raw { contract_addr, .. } => {
+                SystemResult::Err(SystemError::NoSuchContract {
+                    addr: contract_addr.clone(),
+                })
+            }
+            WasmQuery::ContractInfo { contract_addr, .. } => {
+                SystemResult::Err(SystemError::NoSuchContract {
+                    addr: contract_addr.clone(),
+                })
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn test_get_price() {
+        // Arbitrary unix timestamp to coordinate the price feed timestamp and the block time.
+        let current_unix_time = 10_000_000;
+
+        let mut mock_pyth = MockPyth::new(Duration::from_secs(60), Coin::new(1, "foo"), &[]);
+        mock_pyth.add_feed_with_price(PriceIdentifier::from_hex(PRICE_ID).unwrap(), Price { price: 100, conf: 10, expo: -1, publish_time: current_unix_time });
+
+        let (mut deps, env) = setup_test(&default_state(), &mock_pyth, current_unix_time);
+
+        let msg = QueryMsg::FetchPrice { };
+        let result = query(deps.as_ref(), env, msg).and_then(|binary| from_binary::<FetchPriceResponse>(&binary));
+
+        assert_eq!(result.map(|r| r.current_price.price), Ok(100));
+    }
+}

--- a/examples/cw-contract/src/contract.rs
+++ b/examples/cw-contract/src/contract.rs
@@ -194,9 +194,15 @@ mod test {
         let current_unix_time = 10_000_000;
 
         let mut mock_pyth = MockPyth::new(Duration::from_secs(60), Coin::new(1, "foo"), &[]);
-        mock_pyth.add_feed_with_price(PriceIdentifier::from_hex(PRICE_ID).unwrap(), Price { price: 100, conf: 10, expo: -1, publish_time: current_unix_time });
+        let price_feed = PriceFeed::new(
+            PriceIdentifier::from_hex(PRICE_ID).unwrap(),
+            Price { price: 100, conf: 10, expo: -1, publish_time: current_unix_time },
+            Price { price: 200, conf: 20, expo: -1, publish_time: current_unix_time },
+        );
 
-        let (mut deps, env) = setup_test(&default_state(), &mock_pyth, current_unix_time);
+        mock_pyth.add_feed(price_feed);
+
+        let (deps, env) = setup_test(&default_state(), &mock_pyth, current_unix_time);
 
         let msg = QueryMsg::FetchPrice { };
         let result = query(deps.as_ref(), env, msg).and_then(|binary| from_binary::<FetchPriceResponse>(&binary));

--- a/examples/sol-contract/Cargo.toml
+++ b/examples/sol-contract/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["cdylib", "lib"]
 borsh = "0.9"
 arrayref = "0.3.6"
 solana-program = ">= 1.10, < 1.15"
-pyth-sdk-solana = { path = "../../pyth-sdk-solana", version = "0.7.0" }
+pyth-sdk-solana = { path = "../../pyth-sdk-solana", version = "0.8.0" }

--- a/pyth-sdk-cw/Cargo.toml
+++ b/pyth-sdk-cw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-cw"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -10,11 +10,14 @@ description = "pyth price oracle data structures and example usage"
 keywords = [ "pyth", "cw", "cosmwasm", "oracle" ]
 readme = "README.md"
 
+[features]
+test-utils = []
+
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.7.0" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.8.0" }
 schemars = "0.8.1"
 
 [dev-dependencies]

--- a/pyth-sdk-cw/schema/query_msg.json
+++ b/pyth-sdk-cw/schema/query_msg.json
@@ -3,6 +3,12 @@
   "title": "QueryMsg",
   "oneOf": [
     {
+      "type": "string",
+      "enum": [
+        "get_valid_time_period"
+      ]
+    },
+    {
       "type": "object",
       "required": [
         "price_feed"
@@ -21,9 +27,36 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "get_update_fee"
+      ],
+      "properties": {
+        "get_update_fee": {
+          "type": "object",
+          "required": [
+            "vaas"
+          ],
+          "properties": {
+            "vaas": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Binary"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
     "Identifier": {
       "type": "string"
     }

--- a/pyth-sdk-cw/src/lib.rs
+++ b/pyth-sdk-cw/src/lib.rs
@@ -1,10 +1,19 @@
-use std::time::Duration;
-use cosmwasm_std::{to_binary, Addr, QuerierWrapper, QueryRequest, StdResult, WasmQuery, Binary, Coin};
+use cosmwasm_std::{
+    to_binary,
+    Addr,
+    Binary,
+    Coin,
+    QuerierWrapper,
+    QueryRequest,
+    StdResult,
+    WasmQuery,
+};
 use schemars::JsonSchema;
 use serde::{
     Deserialize,
     Serialize,
 };
+use std::time::Duration;
 
 pub use pyth_sdk::{
     Price,
@@ -45,7 +54,8 @@ pub fn query_price_feed(
     Ok(price_feed_response)
 }
 
-/// Get the fee required in order to update the on-chain state with the provided `price_update_vaas`.
+/// Get the fee required in order to update the on-chain state with the provided
+/// `price_update_vaas`.
 pub fn get_update_fee(
     querier: &QuerierWrapper,
     contract_addr: Addr,
@@ -53,17 +63,16 @@ pub fn get_update_fee(
 ) -> StdResult<Coin> {
     querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: contract_addr.into_string(),
-        msg: to_binary(&QueryMsg::GetUpdateFee { vaas: price_update_vaas.to_vec() })?,
+        msg:           to_binary(&QueryMsg::GetUpdateFee {
+            vaas: price_update_vaas.to_vec(),
+        })?,
     }))
 }
 
 /// Get the default length of time for which a price update remains valid.
-pub fn get_valid_time_period(
-    querier: &QuerierWrapper,
-    contract_addr: Addr,
-) -> StdResult<Duration> {
+pub fn get_valid_time_period(querier: &QuerierWrapper, contract_addr: Addr) -> StdResult<Duration> {
     querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: contract_addr.into_string(),
-        msg: to_binary(&QueryMsg::GetValidTimePeriod )?,
+        msg:           to_binary(&QueryMsg::GetValidTimePeriod)?,
     }))
 }

--- a/pyth-sdk-cw/src/test_utils.rs
+++ b/pyth-sdk-cw/src/test_utils.rs
@@ -1,72 +1,82 @@
-use std::time::Duration;
-use std::u128;
-use cosmwasm_std::Coin;
-use {
-  cosmwasm_std::{
+use crate::{
+    PriceFeedResponse,
+    QueryMsg,
+};
+use cosmwasm_std::{
     from_binary,
     to_binary,
     Binary,
+    Coin,
     ContractResult,
     QuerierResult,
     SystemError,
     SystemResult,
-  },
-  std::collections::HashMap,
 };
-use pyth_sdk::{PriceFeed, PriceIdentifier};
-use crate::{PriceFeedResponse, QueryMsg};
+use pyth_sdk::{
+    PriceFeed,
+    PriceIdentifier,
+};
+use std::collections::HashMap;
+use std::time::Duration;
+use std::u128;
 
 /// Mock version of Pyth for testing cosmwasm contracts.
 /// This mock stores some price feeds and responds to query messages.
 #[derive(Clone)]
 pub struct MockPyth {
-  pub valid_time_period: Duration,
-  pub fee_per_vaa: Coin,
-  pub feeds: HashMap<PriceIdentifier, PriceFeed>,
+    pub valid_time_period: Duration,
+    pub fee_per_vaa:       Coin,
+    pub feeds:             HashMap<PriceIdentifier, PriceFeed>,
 }
 
 impl MockPyth {
+    /// Create a new `MockPyth`. You can either provide the full list of price feeds up front,
+    /// or add them later via `add_feed`.
+    pub fn new(valid_time_period: Duration, fee_per_vaa: Coin, feeds: &[PriceFeed]) -> Self {
+        let mut feeds_map = HashMap::new();
+        for feed in feeds {
+            feeds_map.insert(feed.id, *feed);
+        }
 
-  /// Create a new `MockPyth`. You can either provide the full list of price feeds up front,
-  /// or add them later via `add_feed`.
-  pub fn new(valid_time_period: Duration,
-             fee_per_vaa: Coin,
-             feeds: &[PriceFeed]) -> Self {
-    let mut feeds_map = HashMap::new();
-    for feed in feeds {
-      feeds_map.insert(feed.id, *feed);
+        MockPyth {
+            valid_time_period,
+            fee_per_vaa,
+            feeds: feeds_map,
+        }
     }
 
-    MockPyth { valid_time_period, fee_per_vaa, feeds: feeds_map }
-  }
-
-  /// Add a price feed that will be returned on queries.
-  pub fn add_feed(&mut self, feed: PriceFeed) {
-    self.feeds.insert(feed.id, feed);
-  }
-
-  /// Handler for processing query messages. See the tests in `contract.rs` for how to use this
-  /// handler within your tests.
-  pub fn handle_wasm_query(&self, msg: &Binary) -> QuerierResult {
-    let query_msg = from_binary::<QueryMsg>(msg);
-    match query_msg {
-      Ok(QueryMsg::PriceFeed { id }) => match self.feeds.get(&id) {
-        Some(feed) => SystemResult::Ok(
-          to_binary(&PriceFeedResponse {
-            price_feed: *feed,
-          }).into(),
-        ),
-        None => SystemResult::Ok(ContractResult::Err("unknown price feed".into())),
-      },
-      Ok(QueryMsg::GetValidTimePeriod) => SystemResult::Ok(to_binary(&self.valid_time_period).into()),
-      Ok(QueryMsg::GetUpdateFee { vaas}) => {
-        let new_amount = self.fee_per_vaa.amount.u128().checked_mul(vaas.len() as u128).unwrap();
-        SystemResult::Ok(to_binary(&Coin::new(new_amount, &self.fee_per_vaa.denom)).into())
-      },
-      Err(_e) => SystemResult::Err(SystemError::InvalidRequest {
-        error:   "Invalid message".into(),
-        request: msg.clone(),
-      }),
+    /// Add a price feed that will be returned on queries.
+    pub fn add_feed(&mut self, feed: PriceFeed) {
+        self.feeds.insert(feed.id, feed);
     }
-  }
+
+    /// Handler for processing query messages. See the tests in `contract.rs` for how to use this
+    /// handler within your tests.
+    pub fn handle_wasm_query(&self, msg: &Binary) -> QuerierResult {
+        let query_msg = from_binary::<QueryMsg>(msg);
+        match query_msg {
+            Ok(QueryMsg::PriceFeed { id }) => match self.feeds.get(&id) {
+                Some(feed) => {
+                    SystemResult::Ok(to_binary(&PriceFeedResponse { price_feed: *feed }).into())
+                }
+                None => SystemResult::Ok(ContractResult::Err("unknown price feed".into())),
+            },
+            Ok(QueryMsg::GetValidTimePeriod) => {
+                SystemResult::Ok(to_binary(&self.valid_time_period).into())
+            }
+            Ok(QueryMsg::GetUpdateFee { vaas }) => {
+                let new_amount = self
+                    .fee_per_vaa
+                    .amount
+                    .u128()
+                    .checked_mul(vaas.len() as u128)
+                    .unwrap();
+                SystemResult::Ok(to_binary(&Coin::new(new_amount, &self.fee_per_vaa.denom)).into())
+            }
+            Err(_e) => SystemResult::Err(SystemError::InvalidRequest {
+                error:   "Invalid message".into(),
+                request: msg.clone(),
+            }),
+        }
+    }
 }

--- a/pyth-sdk-cw/src/test_utils.rs
+++ b/pyth-sdk-cw/src/test_utils.rs
@@ -1,0 +1,80 @@
+use std::time::Duration;
+use std::u128;
+use cosmwasm_std::Coin;
+use {
+  cosmwasm_std::{
+    from_binary,
+    to_binary,
+    Binary,
+    ContractResult,
+    QuerierResult,
+    SystemError,
+    SystemResult,
+  },
+  std::collections::HashMap,
+};
+use pyth_sdk::{Price, PriceFeed, PriceIdentifier};
+use crate::{PriceFeedResponse, QueryMsg};
+
+/// Mock version of Pyth for testing cosmwasm contracts.
+/// This mock stores some price feeds and responds to query messages.
+#[derive(Clone)]
+pub struct MockPyth {
+  pub valid_time_period: Duration,
+  pub fee_per_vaa: Coin,
+  pub feeds: HashMap<PriceIdentifier, PriceFeed>,
+}
+
+impl MockPyth {
+  pub fn new(valid_time_period: Duration,
+             fee_per_vaa: Coin,
+             feeds: &[PriceFeed]) -> Self {
+    let mut feeds_map = HashMap::new();
+    for feed in feeds {
+      feeds_map.insert(feed.id, *feed);
+    }
+
+    MockPyth { valid_time_period, fee_per_vaa, feeds: feeds_map }
+  }
+
+  /// Add a price feed that will be returned on queries.
+  pub fn add_feed(&mut self, feed: PriceFeed) {
+    self.feeds.insert(feed.id, feed);
+  }
+
+  /// Add a price feed containing `price` as both the current price and EMA.
+  pub fn add_feed_with_price(&mut self, id: PriceIdentifier, price: Price) {
+    let feed = PriceFeed::new(
+      id,
+      price,
+      price,
+    );
+    self.feeds.insert(id, feed);
+  }
+
+  /// Handler for processing query messages. See the tests in `contract.rs` for how to use this
+  /// handler within your tests.
+  pub fn handle_wasm_query(&self, msg: &Binary) -> QuerierResult {
+    let query_msg = from_binary::<QueryMsg>(msg);
+    match query_msg {
+      Ok(QueryMsg::PriceFeed { id }) => match self.feeds.get(&id) {
+        Some(feed) => SystemResult::Ok(ContractResult::Ok(
+          to_binary(&PriceFeedResponse {
+            price_feed: *feed,
+          })
+            .unwrap(),
+        )),
+        None => SystemResult::Ok(ContractResult::Err("unknown price feed".into())),
+      },
+      Ok(QueryMsg::GetValidTimePeriod) => SystemResult::Ok(ContractResult::Ok(to_binary(&self.valid_time_period).unwrap())),
+      Ok(QueryMsg::GetUpdateFee { vaas}) => {
+        let new_amount = self.fee_per_vaa.amount.u128().checked_mul(vaas.len() as u128).unwrap();
+        SystemResult::Ok(ContractResult::Ok(to_binary(&Coin::new(new_amount, &self.fee_per_vaa.denom)).unwrap()))
+      },
+      Err(_e) => SystemResult::Err(SystemError::InvalidRequest {
+        error:   "Invalid message".into(),
+        request: msg.clone(),
+      }),
+    }
+  }
+}

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
-pyth-sdk = { path = "../pyth-sdk", version = "0.7.0" }
+pyth-sdk = { path = "../pyth-sdk", version = "0.8.0" }
 
 [dev-dependencies]
 solana-client = ">= 1.9, < 1.15"

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -8,7 +8,7 @@ test-bpf = []
 no-entrypoint = []
 
 [dependencies]
-pyth-sdk-solana = { path = "../", version = "0.7.0" }
+pyth-sdk-solana = { path = "../", version = "0.8.0" }
 solana-program = ">= 1.10, < 1.15"
 bytemuck = "1.7.2"
 borsh = "0.9"

--- a/pyth-sdk/Cargo.toml
+++ b/pyth-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -121,7 +121,6 @@ impl PriceFeed {
         }
     }
 
-
     /// Get the "unchecked" price and confidence interval as fixed-point numbers of the form
     /// a * 10^e along with its publish time.
     ///

--- a/pyth-sdk/src/price.rs
+++ b/pyth-sdk/src/price.rs
@@ -232,6 +232,16 @@ impl Price {
         })
     }
 
+    /// Divide this `Price` by a constant `c * 10^e`.
+    pub fn cdiv(&self, c: i64, e: i32) -> Option<Price> {
+        self.div(&Price {
+            price: c,
+            conf: 0,
+            expo: e,
+            publish_time: self.publish_time,
+        })
+    }
+
     /// Multiply this `Price` by `other`, propagating any uncertainty.
     pub fn mul(&self, other: &Price) -> Option<Price> {
         // Price is not guaranteed to store its price/confidence in normalized form.

--- a/pyth-sdk/src/price.rs
+++ b/pyth-sdk/src/price.rs
@@ -235,9 +235,9 @@ impl Price {
     /// Divide this `Price` by a constant `c * 10^e`.
     pub fn cdiv(&self, c: i64, e: i32) -> Option<Price> {
         self.div(&Price {
-            price: c,
-            conf: 0,
-            expo: e,
+            price:        c,
+            conf:         0,
+            expo:         e,
             publish_time: self.publish_time,
         })
     }


### PR DESCRIPTION
The main change here is that I added a MockPyth struct to help developers test their CW contracts using Pyth. This struct is in pyth-sdk-cw and enabled by the "test-utils" feature flag. I added an example to `contract.rs` showing how to use this mock.

Couple of other minor changes in here:
* Added new query functions to get the update fee and valid time period
* Bumped all the crate versions
* Added a `cdiv` function to `Price`, which is analogous to the existing `cmul` function. (I want this to do a more complex example contract)