### PR TITLE
Add workflow for the solana-anchor best-practice example

### DIFF
--- a/.github/workflows/pyth-sdk-example-anchor-contract.yml
+++ b/.github/workflows/pyth-sdk-example-anchor-contract.yml
@@ -1,0 +1,33 @@
+name: Pyth SDK Example Solana Contract with Anchor Library
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./examples/sol-anchor-contract
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install libudev-dev pkg-config build-essential
+    - name: Install solana binaries
+      run: |
+        # Installing 1.14.x cli tools to have sbf instead of bpf. bpf does not work anymore.
+        sh -c "$(curl -sSfL https://release.solana.com/v1.14.7/install)"
+        echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+    - name: Install anchor binaries
+      run: |
+        cargo install --git https://github.com/project-serum/anchor avm --locked --force
+        avm install latest
+        avm use latest
+    - name: Build
+      run: anchor build


### PR DESCRIPTION
There is one minor issue. The step of `Install anchor binaries` takes ~15min, which seems very long.