### PR TITLE
pyth-sdk-solana: Add constraints between SDK and oracle program types.

### DIFF
--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -24,6 +24,10 @@ pyth-sdk = { path = "../pyth-sdk", version = "0.7.0" }
 [dev-dependencies]
 solana-client = ">= 1.9, < 1.15"
 solana-sdk = ">= 1.9, < 1.15"
+pyth-oracle = { path = "../../pyth-client/program/rust", features = ["library"] }
+
+[features]
+default = []
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
The types defined here in theory should be byte-equivalent to those defined in the `pyth-oracle` program. It is difficult to check this without comparing the two sources together. This PR adds the oracle contract as a dependency during testing and attempts to convert between the prices and compare byte sizes to add some confidence that these don't go out of sync. It's also possible then to have this library directly depend on a specific version of the oracle program so that we're forced to identify which version the types depend on for better release numbering.

I did this because I have need for this library within pythnet and this was a pain point.