### PR TITLE
Fix struct size discrepancy by specifying enum representation

### DIFF
--- a/pyth-sdk-solana/src/state.rs
+++ b/pyth-sdk-solana/src/state.rs
@@ -47,7 +47,7 @@ pub const PROD_ATTR_SIZE: usize = PROD_ACCT_SIZE - PROD_HDR_SIZE;
     serde::Serialize,
     serde::Deserialize,
 )]
-#[repr(C)]
+#[repr(u8)]
 pub enum AccountType {
     Unknown,
     Mapping,
@@ -74,7 +74,7 @@ impl Default for AccountType {
     serde::Serialize,
     serde::Deserialize,
 )]
-#[repr(C)]
+#[repr(u8)]
 pub enum CorpAction {
     NoCorpAct,
 }
@@ -98,7 +98,7 @@ impl Default for CorpAction {
     serde::Serialize,
     serde::Deserialize,
 )]
-#[repr(C)]
+#[repr(u8)]
 pub enum PriceType {
     Unknown,
     Price,
@@ -122,7 +122,7 @@ impl Default for PriceType {
     serde::Serialize,
     serde::Deserialize,
 )]
-#[repr(C)]
+#[repr(u8)]
 pub enum PriceStatus {
     /// The price feed is not currently updating for an unknown reason.
     Unknown,


### PR DESCRIPTION
This commit resolves a size discrepancy issue observed with structs derived from the Pyth SDK when executed on Solana's runtime vs off-chain. The use of `#[repr(C)]` in enum definitions, leading to an unexpected increase in struct sizes when compiled for the Solana BPF target, causing the SDK to fail deserialization.
The account size for std::mem::size_of::<SolanaPriceAccount>() returned 3840, when the correct size is 3312.

By changing the enum representation from `#[repr(C)]` to `#[repr(u8)]`, we ensure a consistent and minimal size for the enums across both execution environments.