### PR TITLE
Fix struct size discrepancy by specifying enum representation #115

### DIFF
--- a/.github/workflows/pyth-sdk-solana.yml
+++ b/.github/workflows/pyth-sdk-solana.yml
@@ -34,14 +34,13 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libudev-dev
     - name: Install Solana Binaries
       run: |
-        # Installing 1.17.x cli tools to have sbf instead of bpf. bpf does not work anymore.
-        sh -c "$(curl -sSfL https://release.solana.com/v1.18.1/install)"
+        sh -c "$(curl -sSfL https://release.solana.com/v1.18.4/install)"
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
-    - name: Build BPF
-      run: cargo build-bpf --verbose
-    - name: Run BPF tests
-      run: cargo test-bpf --verbose
+    - name: Build SBF
+      run: cargo build-sbf --verbose
+    - name: Run SBF tests
+      run: cargo test-sbf --verbose

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pyth-sdk-solana/src/state.rs
+++ b/pyth-sdk-solana/src/state.rs
@@ -47,7 +47,7 @@ pub const PROD_ATTR_SIZE: usize = PROD_ACCT_SIZE - PROD_HDR_SIZE;
     serde::Serialize,
     serde::Deserialize,
 )]
-#[repr(C)]
+#[repr(u8)]
 pub enum AccountType {
     Unknown,
     Mapping,
@@ -74,7 +74,7 @@ impl Default for AccountType {
     serde::Serialize,
     serde::Deserialize,
 )]
-#[repr(C)]
+#[repr(u8)]
 pub enum CorpAction {
     NoCorpAct,
 }
@@ -98,7 +98,7 @@ impl Default for CorpAction {
     serde::Serialize,
     serde::Deserialize,
 )]
-#[repr(C)]
+#[repr(u8)]
 pub enum PriceType {
     Unknown,
     Price,
@@ -122,7 +122,7 @@ impl Default for PriceType {
     serde::Serialize,
     serde::Deserialize,
 )]
-#[repr(C)]
+#[repr(u8)]
 pub enum PriceStatus {
     /// The price feed is not currently updating for an unknown reason.
     Unknown,

--- a/pyth-sdk-solana/test-contract/rust-toolchain
+++ b/pyth-sdk-solana/test-contract/rust-toolchain
@@ -1,5 +1,5 @@
 
 # This is only used for tests
 [toolchain]
-channel = "1.71.0"
+channel = "1.76.0"
 profile = "minimal"


### PR DESCRIPTION
Same as #115.

This commit resolves a size discrepancy issue observed with structs derived from the Pyth SDK when executed on Solana's runtime vs off-chain. The use of #[repr(C)] in enum definitions, leading to an unexpected increase in struct sizes when compiled for the Solana BPF target, causing the SDK to fail deserialization.
The account size for std::mem::size_of::() returned 3840, when the correct size is 3312.

By changing the enum representation from #[repr(C)] to #[repr(u8)], we ensure a consistent and minimal size for the enums across both execution environments.