### PR TITLE
enabled derive feature for bytemuck crate

### DIFF
--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -14,13 +14,12 @@ readme = "README.md"
 solana-program = ">= 1.9"
 borsh = "0.10.3"
 borsh-derive = "0.10.3"
-bytemuck = "1.7.2"
 num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 pyth-sdk = { path = "../pyth-sdk", version = "0.8.0" }
-
+bytemuck = { version = "1.16.1", features = ["derive"] }
 [dev-dependencies]
 solana-client = ">= 1.9"
 solana-sdk = ">= 1.9"


### PR DESCRIPTION
Fixes #120

This issue was encountered  due to the lack of the derive feature in the bytemuck crate
. By default, the bytemuck crate does not enable the derive feature, 
which provides the necessary macros to derive traits like Zeroable,Pod.