### PR TITLE
Add `metadata` and `vaa` fields in `PriceFeed` struct

### DIFF
--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -106,10 +106,7 @@ pub struct PriceFeedMetadata {
     attestation_time:           Option<u64>,
 
     /// Chain of the emitter
-    emitter_chain:              Option<u64>,
-
-    /// The time that the previous price was published
-    prev_publish_time:          Option<u64>,
+    emitter_chain:              u64,
 
     /// The time that the price service received the price
     price_service_receive_time: Option<u64>,
@@ -120,8 +117,28 @@ pub struct PriceFeedMetadata {
     /// Pythnet slot number of the price
     slot:                       Option<u64>,
 
-    /// Sequence number of the price
-    proof_available_time:       Option<u64>,
+    /// The time that the previous price was published
+    prev_publish_time:          Option<u64>,
+}
+
+impl PriceFeedMetadata {
+    pub fn new(
+        attestation_time: Option<u64>,
+        emitter_chain: u64,
+        price_service_receive_time: Option<u64>,
+        sequence_number: Option<u64>,
+        slot: Option<u64>,
+        prev_publish_time: Option<u64>
+    ) -> Self {
+        Self {
+            attestation_time,
+            emitter_chain,
+            prev_publish_time,
+            price_service_receive_time,
+            sequence_number,
+            slot,
+        }
+    }
 }
 
 /// Represents a current aggregation price from pyth publisher feeds.

--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -116,6 +116,9 @@ pub struct PriceFeedMetadata {
 
     /// Pythnet slot number of the price
     slot: Option<u64>,
+
+    /// Sequence number of the price
+    proof_available_time: Option<u64>,
 }
 
 /// Represents a current aggregation price from pyth publisher feeds.

--- a/pyth-sdk/src/lib.rs
+++ b/pyth-sdk/src/lib.rs
@@ -244,6 +244,20 @@ impl PriceFeed {
 
         Some(price)
     }
+
+    /// Get the price feed metadata.
+    ///
+    /// Returns `None` if metadata is currently unavailable.
+    pub fn get_metadata(&self) -> Option<PriceFeedMetadata> {
+        self.metadata
+    }
+
+    /// Get the price feed vaa.
+    ///
+    /// Returns `None` if vaa  is unavailable.
+    pub fn get_vaa(&self) -> Option<String> {
+        self.vaa.clone()
+    }
 }
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
#### Motivation
- Based on [TS sdk], `PriceFeed` struct has 5 fields. Currently, Rust sdk has only 3 fields. 

[TS sdk]: https://github.com/pyth-network/pyth-crosschain/blob/main/price_service/sdk/js/src/schemas/PriceFeed.ts

#### Solution
- Add missing `metadata` and `vaa` fields.