### PR TITLE
fix: add version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ members = [
 ]
 
 [workspace.dependencies]
-pyth-sdk = { path = "./pyth-sdk" }
-pyth-sdk-solana = { path = "./pyth-sdk-solana" }
+pyth-sdk = { path = "./pyth-sdk", version = "0.8.0" }
+pyth-sdk-solana = { path = "./pyth-sdk-solana", version = "0.10.4" }
 
 solana-program = ">= 1.10"
 borsh = "0.10.3"


### PR DESCRIPTION
I made a mistake and thought removing redundant version would help but it caught me during the publish of the package.