### PR TITLE
refactor(pyth-sdk-solana): refactor attribute iterators

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -16,4 +16,4 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rustfmt
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pyth-sdk-example-anchor-contract.yml
+++ b/.github/workflows/pyth-sdk-example-anchor-contract.yml
@@ -21,7 +21,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libudev-dev pkg-config build-essential protobuf-compiler
     - name: Install solana binaries
       run: |
-        sh -c "$(curl -sSfL https://release.solana.com/v1.18.21/install)"
+        sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.21/install)"
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Install anchor binaries
       run: |

--- a/.github/workflows/pyth-sdk-example-solana-contract.yml
+++ b/.github/workflows/pyth-sdk-example-solana-contract.yml
@@ -21,7 +21,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libudev-dev protobuf-compiler
     - name: Install solana binaries
       run: |
-        sh -c "$(curl -sSfL https://release.solana.com/v1.18.21/install)"
+        sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.21/install)"
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Build
       run: scripts/build.sh

--- a/.github/workflows/pyth-sdk-solana.yml
+++ b/.github/workflows/pyth-sdk-solana.yml
@@ -34,7 +34,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libudev-dev protobuf-compiler
     - name: Install Solana Binaries
       run: |
-        sh -c "$(curl -sSfL https://release.solana.com/v1.18.21/install)"
+        sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.21/install)"
         echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
     - name: Build
       run: cargo build --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk-solana"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "borsh 0.10.3",
  "borsh-derive 0.10.3",

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["Pyth Data Foundation"]
 workspace = "../"
 edition = "2018"


### PR DESCRIPTION
There are some assumptions outside this SDK on the product attributes and the `size` field in particular that guarantee that the accesses are safe. This commit refactors it to add extra levels of safety to not rely on those assumptions.