### PR TITLE
chore(pyth-sdk-solana): add notice and bump to 0.10.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk-solana"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "borsh 0.10.4",
  "borsh-derive 0.10.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [workspace.dependencies]
 pyth-sdk = { path = "./pyth-sdk", version = "0.8.0" }
-pyth-sdk-solana = { path = "./pyth-sdk-solana", version = "0.10.4" }
+pyth-sdk-solana = { path = "./pyth-sdk-solana", version = "0.10.6" }
 
 solana-program = ">= 1.10"
 borsh = "0.10.4"

--- a/examples/sol-anchor-contract/programs/sol-anchor-contract/Cargo.toml
+++ b/examples/sol-anchor-contract/programs/sol-anchor-contract/Cargo.toml
@@ -20,4 +20,4 @@ default = []
 anchor-lang = "0.28.0"
 pyth-sdk = { path = "../../../../pyth-sdk", version = "0.8.0" }
 solana-program = ">= 1.10, < 2.0"
-pyth-sdk-solana = { path = "../../../../pyth-sdk-solana", version = "0.10.2" }
+pyth-sdk-solana = { path = "../../../../pyth-sdk-solana", version = "0.10.6" }

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-solana"
-version = "0.10.5"
+version = "0.10.6"
 authors = ["Pyth Data Foundation"]
 workspace = "../"
 edition = "2018"

--- a/pyth-sdk-solana/README.md
+++ b/pyth-sdk-solana/README.md
@@ -1,5 +1,7 @@
 # Pyth Network Solana SDK
 
+> Notice: This crate contains the internal implementation details of Pyth on Pythnet. If you want to use Pyth prices on Solana, use the [pyth-solana-receiver-sdk](https://crates.io/crates/pyth-solana-receiver-sdk) crate instead.
+
 This crate provides utilities for reading price feeds from the [pyth.network](https://pyth.network/) oracle on the Solana network.
 It also includes several [off-chain example programs](examples/).
 

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -9,7 +9,7 @@ test-bpf = []
 no-entrypoint = []
 
 [dependencies]
-pyth-sdk-solana = { path = "../", version = "0.10.0" }
+pyth-sdk-solana = { path = "../", version = "0.10.6" }
 solana-program = ">= 1.10"
 bytemuck = "1.7.2"
 borsh = "0.10.3"


### PR DESCRIPTION
## Summary
- Add a clear notice to `pyth-sdk-solana` README explaining that this crate contains internal implementation details of Pyth on Pythnet.
- Direct Solana users to `https://crates.io/crates/pyth-solana-receiver-sdk`.
- Bump `pyth-sdk-solana` to `0.10.6` and align dependent manifests so we can publish with the updated README.

## Test plan
- `cargo build --workspace` succeeds locally.
- No functional code changes; README + version only.